### PR TITLE
fix: Restore database-docker-build to build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build-%:
 	$(MAKE) $*-docker-build
 
 .PHONY: build
-build: backend-docker-build frontend-docker-build runtime-docker-build backend-python-docker-build
+build:  database-docker-build backend-docker-build frontend-docker-build runtime-docker-build backend-python-docker-build
 
 .PHONY: create-namespace
 create-namespace:


### PR DESCRIPTION
Re-adds the 'database-docker-build' step to the build process. This target was accidentally removed in PR #79.