### PR TITLE
feat(annotation): simplify task creation and streamline sync workflow

### DIFF
--- a/frontend/src/pages/DataAnnotation/AutoAnnotation/AutoAnnotation.tsx
+++ b/frontend/src/pages/DataAnnotation/AutoAnnotation/AutoAnnotation.tsx
@@ -9,8 +9,7 @@ import {
 	EditOutlined,
 	MoreOutlined,
 	SettingOutlined,
-	ExportOutlined,
-	ImportOutlined,
+	SyncOutlined,
 } from "@ant-design/icons";
 import type { ColumnType } from "antd/es/table";
 import type { AutoAnnotationTask, AutoAnnotationStatus } from "../annotation.model";
@@ -18,8 +17,7 @@ import {
 	queryAutoAnnotationTasksUsingGet,
 	deleteAutoAnnotationTaskByIdUsingDelete,
 	downloadAutoAnnotationResultUsingGet,
-  queryAnnotationTasksUsingGet,
-  syncAutoAnnotationTaskToLabelStudioUsingPost,
+	queryAnnotationTasksUsingGet,
 } from "../annotation.api";
 import CreateAutoAnnotationDialog from "./components/CreateAutoAnnotationDialog";
 import EditAutoAnnotationDatasetDialog from "./components/EditAutoAnnotationDatasetDialog";
@@ -159,34 +157,6 @@ export default function AutoAnnotation() {
 		}
 	};
 
-	const handleSyncToLabelStudio = (task: AutoAnnotationTask) => {
-		if (task.status !== "completed") {
-			message.warning("仅已完成的任务可以同步到 Label Studio");
-			return;
-		}
-
-		Modal.confirm({
-			title: `确认同步自动标注任务「${task.name}」到 Label Studio 吗？`,
-			content: (
-				<div>
-					<div>将把该任务的检测结果作为预测框写入 Label Studio。</div>
-					<div>不会覆盖已有人工标注，仅作为可编辑的预测结果。</div>
-				</div>
-			),
-			okText: "同步",
-			cancelText: "取消",
-			onOk: async () => {
-				try {
-					await syncAutoAnnotationTaskToLabelStudioUsingPost(task.id);
-					message.success("同步请求已发送");
-				} catch (error) {
-					console.error(error);
-					message.error("同步失败，请稍后重试");
-				}
-			},
-		});
-	};
-
 	const handleAnnotate = (task: AutoAnnotationTask) => {
 		const datasetId = task.datasetId;
 		if (!datasetId) {
@@ -322,21 +292,11 @@ export default function AutoAnnotation() {
 		{
 			title: "操作",
 			key: "actions",
-			width: 320,
+			width: 300,
 			fixed: "right",
 			render: (_: any, record: AutoAnnotationTask) => (
 				<Space size="small">
-					{/* 一级功能菜单：前向同步 + 编辑（跳转 Label Studio） */}
-					<Tooltip title="将 YOLO 预测结果前向同步到 Label Studio">
-						<Button
-							type="link"
-							size="small"
-							icon={<ExportOutlined />}
-							onClick={() => handleSyncToLabelStudio(record)}
-						>
-							前向同步
-						</Button>
-					</Tooltip>
+					{/* 一级功能：编辑（跳转 Label Studio） + 同步（导回结果） */}
 					<Tooltip title="在 Label Studio 中手动标注">
 						<Button
 							type="link"
@@ -347,14 +307,14 @@ export default function AutoAnnotation() {
 							编辑
 						</Button>
 					</Tooltip>
-					<Tooltip title="从 Label Studio 导回标注结果到数据集">
+					<Tooltip title="从 Label Studio 同步标注结果到数据集">
 						<Button
 							type="link"
 							size="small"
-							icon={<ImportOutlined />}
+							icon={<SyncOutlined />}
 							onClick={() => handleImportFromLabelStudio(record)}
 						>
-							后向同步
+							同步
 						</Button>
 					</Tooltip>
 

--- a/frontend/src/pages/DataAnnotation/AutoAnnotation/components/CreateAutoAnnotationDialog.tsx
+++ b/frontend/src/pages/DataAnnotation/AutoAnnotation/components/CreateAutoAnnotationDialog.tsx
@@ -188,7 +188,6 @@ export default function CreateAutoAnnotationDialog({
 					modelSize: values.modelSize,
 					confThreshold: values.confThreshold,
 					targetClasses: selectAllClasses ? [] : values.targetClasses || [],
-					outputDatasetName: values.outputDatasetName || undefined,
 				},
 			};
 
@@ -243,6 +242,7 @@ export default function CreateAutoAnnotationDialog({
 							form.setFieldsValue({ datasetId: dataset?.id ?? "" });
 						}}
 						datasetTypeFilter={DatasetType.IMAGE}
+						singleDatasetOnly
 					/>
 					{selectedDataset && (
 						<div className="mt-2 p-2 bg-blue-50 rounded border border-blue-200 text-xs">
@@ -291,9 +291,6 @@ export default function CreateAutoAnnotationDialog({
 					)}
 				</Form.Item>
 
-				<Form.Item name="outputDatasetName" label="输出数据集名称 (可选)">
-					<Input placeholder="留空则将结果写入原数据集的标签中" />
-				</Form.Item>
 			</Form>
 		</Modal>
 	);

--- a/frontend/src/pages/DataAnnotation/AutoAnnotation/components/EditAutoAnnotationDatasetDialog.tsx
+++ b/frontend/src/pages/DataAnnotation/AutoAnnotation/components/EditAutoAnnotationDatasetDialog.tsx
@@ -186,6 +186,8 @@ export default function EditAutoAnnotationDatasetDialog({
               setSelectedDataset(dataset);
             }}
             datasetTypeFilter={DatasetType.IMAGE}
+            singleDatasetOnly
+            fixedDatasetId={task.datasetId}
             lockedFileIds={Array.from(initialFileIds)}
           />
           {selectedDataset && (

--- a/frontend/src/pages/DataAnnotation/EditManualAnnotationDatasetDialog.tsx
+++ b/frontend/src/pages/DataAnnotation/EditManualAnnotationDatasetDialog.tsx
@@ -164,7 +164,9 @@ export default function EditManualAnnotationDatasetDialog({
             onDatasetSelect={(dataset) => {
               setSelectedDataset(dataset as Dataset | null);
             }}
-            // 手动标注支持所有数据集/文件类型，这里不设置 datasetTypeFilter
+            // 手动标注支持所有数据集/文件类型，但编辑时仅允许在创建任务的数据集中追加
+            singleDatasetOnly
+            fixedDatasetId={task.datasetId}
             lockedFileIds={Array.from(initialFileIds)}
           />
           <div className="mt-2 p-2 bg-blue-50 rounded border border-blue-200 text-xs">

--- a/frontend/src/pages/DataAnnotation/Home/DataAnnotation.tsx
+++ b/frontend/src/pages/DataAnnotation/Home/DataAnnotation.tsx
@@ -20,7 +20,6 @@ import {
   syncAnnotationTaskUsingPost,
   queryAutoAnnotationTasksUsingGet,
   deleteAutoAnnotationTaskByIdUsingDelete,
-  syncAutoAnnotationTaskToLabelStudioUsingPost,
   getAutoAnnotationLabelStudioProjectUsingGet,
   loginAnnotationUsingGet,
 } from "../annotation.api";
@@ -278,34 +277,6 @@ export default function DataAnnotation() {
     setShowImportAutoDialog(true);
   };
 
-  const handleSyncAutoToLabelStudio = (task: any) => {
-    if (task.autoStatus !== "completed") {
-      message.warning("仅已完成的自动标注任务可以同步到 Label Studio");
-      return;
-    }
-
-    Modal.confirm({
-      title: `确认同步自动标注任务「${task.name}」到 Label Studio 吗？`,
-      content: (
-        <div>
-          <div>将把该任务的检测结果作为预测框写入 Label Studio。</div>
-          <div>不会覆盖已有人工标注，仅作为可编辑的预测结果。</div>
-        </div>
-      ),
-      okText: "同步",
-      cancelText: "取消",
-      onOk: async () => {
-        try {
-          await syncAutoAnnotationTaskToLabelStudioUsingPost(task.id);
-          message.success("自动标注结果同步请求已发送");
-        } catch (e) {
-          console.error(e);
-          message.error("自动标注结果同步失败，请稍后重试");
-        }
-      },
-    });
-  };
-
   const handleAnnotateAuto = (task: any) => {
     (async () => {
       try {
@@ -460,8 +431,8 @@ export default function DataAnnotation() {
     },
     {
       key: "back-sync",
-      label: "后向同步",
-      icon: <ImportOutlined className="w-4 h-4" style={{ color: "#1890ff" }} />,
+      label: "同步",
+      icon: <SyncOutlined className="w-4 h-4" style={{ color: "#1890ff" }} />,
       onClick: handleImportManualFromLabelStudio,
     },
     {
@@ -652,11 +623,11 @@ export default function DataAnnotation() {
               </Button>
               <Button
                 type="text"
-                icon={<ImportOutlined style={{ color: "#1890ff" }} />}
+                icon={<SyncOutlined style={{ color: "#1890ff" }} />}
                 onClick={() => handleImportManualFromLabelStudio(task)}
-                title="从 Label Studio 导回标注结果到数据集"
+                title="从 Label Studio 同步标注结果到数据集"
               >
-                后向同步
+                同步
               </Button>
 
               <Dropdown
@@ -685,15 +656,6 @@ export default function DataAnnotation() {
           )}
           {task._kind === "auto" && (
             <>
-              {/* 一级功能：前向同步 + 编辑（跳转 Label Studio） */}
-              <Button
-                type="text"
-                icon={<ExportOutlined style={{ color: "#722ed1" }} />}
-                onClick={() => handleSyncAutoToLabelStudio(task)}
-                title="将 YOLO 预测结果前向同步到 Label Studio"
-              >
-                前向同步
-              </Button>
               <Button
                 type="text"
                 icon={<EditOutlined style={{ color: "#52c41a" }} />}
@@ -705,11 +667,11 @@ export default function DataAnnotation() {
 
               <Button
                 type="text"
-                icon={<ImportOutlined style={{ color: "#1890ff" }} />}
+                icon={<SyncOutlined style={{ color: "#1890ff" }} />}
                 onClick={() => handleImportAutoFromLabelStudio(task)}
-                title="从 Label Studio 导回标注结果到数据集"
+                title="从 Label Studio 同步标注结果到数据集"
               >
-                后向同步
+                同步
               </Button>
 
               {/* 二级功能：编辑任务数据集 + 删除任务（折叠菜单） */}

--- a/frontend/src/pages/DataAnnotation/annotation.api.ts
+++ b/frontend/src/pages/DataAnnotation/annotation.api.ts
@@ -74,7 +74,7 @@ export function loginAnnotationUsingGet(mappingId: string) {
 // 手动标注：从 Label Studio 导回标注结果到某个数据集（导出为文件写入数据集）
 export function importManualAnnotationFromLabelStudioUsingPost(
   mappingId: string,
-  data: { targetDatasetId: string; exportFormat?: string }
+  data: { exportFormat?: string; fileName?: string }
 ) {
   return post(`/api/annotation/project/${mappingId}/sync-label-studio-back`, data);
 }
@@ -91,7 +91,7 @@ export function syncAutoAnnotationTaskToLabelStudioUsingPost(taskId: string) {
 // 从 Label Studio 导回自动标注任务的标注结果（导出为文件写入指定数据集）
 export function importAutoAnnotationFromLabelStudioUsingPost(
   taskId: string,
-  data: { targetDatasetId: string; exportFormat?: string }
+  data: { exportFormat?: string; fileName?: string }
 ) {
   return post(`/api/annotation/auto/${taskId}/sync-label-studio-back`, data);
 }

--- a/runtime/datamate-python/app/module/annotation/schema/auto.py
+++ b/runtime/datamate-python/app/module/annotation/schema/auto.py
@@ -103,16 +103,16 @@ class UpdateAutoAnnotationTaskFilesRequest(BaseModel):
 class ImportFromLabelStudioRequest(BaseModel):
     """从 Label Studio 导入标注结果到 DM 数据集的请求体。
 
-    - target_dataset_id: 要将导出结果写入的目标数据集ID；
-    - export_format: Label Studio 导出格式（如 JSON/JSON_MIN/CSV/TSV/COCO/YOLO 等）。
-        - file_name: 可选，自定义保存到数据集中的文件名称（不含路径）；
-            若包含扩展名或路径分隔符，服务端会自动裁剪，仅保留文件名主体并附加正确后缀。
+    - target_dataset_id: 目标数据集ID（可选）；若未提供，则自动使用源任务/映射所关联的数据集；
+    - export_format: Label Studio 导出格式（如 JSON/JSON_MIN/CSV/TSV/COCO/YOLO 等）；
+    - file_name: 可选，自定义保存到数据集中的文件名称（不含路径）；
+      若包含扩展名或路径分隔符，服务端会自动裁剪，仅保留文件名主体并附加正确后缀。
     """
 
-    target_dataset_id: str = Field(
-        ...,
+    target_dataset_id: Optional[str] = Field(
+        default=None,
         alias="targetDatasetId",
-        description="导入目标数据集ID",
+        description="导入目标数据集ID（可选，不传则使用源数据集）",
     )
     export_format: str = Field(
         default="JSON",

--- a/runtime/ops/annotation/image_object_detection_bounding_box/process.py
+++ b/runtime/ops/annotation/image_object_detection_bounding_box/process.py
@@ -180,20 +180,14 @@ class ImageObjectDetectionBoundingBox(Mapper):
         else:
             output_dir = os.path.dirname(image_path)
         
-        # 创建输出子目录（可选，用于组织文件）
-        images_dir = os.path.join(output_dir, "images")
+        # 创建输出子目录：仅保留 annotations 目录，不再额外保存标注图像，
+        # 以减少冗余占用；检测结果将直接写入 JSON 文件。
         annotations_dir = os.path.join(output_dir, "annotations")
-        os.makedirs(images_dir, exist_ok=True)
         os.makedirs(annotations_dir, exist_ok=True)
         
         # 保持原始文件名（不添加后缀），确保一一对应
         base_name = os.path.basename(image_path)
         name_without_ext = os.path.splitext(base_name)[0]
-        
-        # 保存标注图像（保持原始扩展名或使用jpg）
-        output_filename = base_name
-        output_path = os.path.join(images_dir, output_filename)
-        cv2.imwrite(output_path, img)
         
         # 保存标注 JSON（文件名与图像对应）
         json_filename = f"{name_without_ext}.json"
@@ -203,7 +197,8 @@ class ImageObjectDetectionBoundingBox(Mapper):
         
         # 更新样本数据
         sample["detection_count"] = len(annotations["detections"])
-        sample["output_image"] = output_path
+        # 不再额外保存 output_image 副本，仅返回原始路径和注释信息
+        sample["output_image"] = image_path
         sample["annotations_file"] = json_path
         sample["annotations"] = annotations
         

--- a/runtime/python-executor/datamate/auto_annotation_worker.py
+++ b/runtime/python-executor/datamate/auto_annotation_worker.py
@@ -28,6 +28,8 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Set
+import urllib.error
+import urllib.request
 
 from loguru import logger
 from sqlalchemy import text
@@ -100,6 +102,13 @@ POLL_INTERVAL_SECONDS = float(os.getenv("AUTO_ANNOTATION_POLL_INTERVAL", "5"))
 DEFAULT_OUTPUT_ROOT = os.getenv(
     "AUTO_ANNOTATION_OUTPUT_ROOT", "/dataset"
 )
+
+BACKEND_BASE_URL = os.getenv(
+    "AUTO_ANNOTATION_BACKEND_URL", "http://datamate-backend-python:18000"
+)
+
+AUTO_SYNC_ENABLED = os.getenv("AUTO_ANNOTATION_SYNC_ENABLED", "true").lower() == "true"
+AUTO_SYNC_TIMEOUT_SECONDS = float(os.getenv("AUTO_ANNOTATION_SYNC_TIMEOUT", "10"))
 
 
 def _fetch_pending_task() -> Optional[Dict[str, Any]]:
@@ -202,6 +211,29 @@ def _update_task_status(
 
     with SQLManager.create_connect() as conn:
         conn.execute(sql, params)
+
+
+def _get_dataset_root(dataset_id: str) -> Optional[str]:
+    """根据数据集ID获取其根路径。
+
+    自动标注结果将写入该路径下的 annotations/<task_id>/annotations 目录中，
+    既复用原有卷，又避免为每次自动标注创建新的数据集。
+    """
+
+    sql = text(
+        """
+        SELECT path
+        FROM t_dm_datasets
+        WHERE id = :dataset_id
+          AND status = 'ACTIVE'
+        """
+    )
+
+    with SQLManager.create_connect() as conn:
+        row = conn.execute(sql, {"dataset_id": dataset_id}).fetchone()
+        if not row:
+            return None
+        return str(row[0]) if row[0] is not None else None
 
 
 def _load_dataset_files(dataset_id: str) -> List[Tuple[str, str, str]]:
@@ -319,205 +351,183 @@ def _update_dataset_file_tags(file_id: str, tags: List[Dict[str, Any]]) -> None:
         )
 
 
+def _register_annotation_output_file(dataset_id: str, annotations_path: str) -> None:
+    """确保自动标注生成的 JSON 结果文件在 t_dm_dataset_files 中有一条记录。
+
+    - 若同一 dataset_id + file_path 已存在，则仅更新文件大小和时间戳；
+    - 若不存在，则插入一条新的 ACTIVE 记录。
+    """
+
+    if not annotations_path:
+        return
+
+    try:
+        if not os.path.isfile(annotations_path):
+            logger.warning(
+                "Annotation JSON file not found when registering dataset file: {}",
+                annotations_path,
+            )
+            return
+
+        file_name = os.path.basename(annotations_path)
+        ext = os.path.splitext(file_name)[1].lstrip(".").lower() or "other"
+
+        try:
+            file_size = os.path.getsize(annotations_path)
+        except OSError:
+            file_size = 0
+
+        now = datetime.utcnow()
+
+        with SQLManager.create_connect() as conn:
+            # 先检查是否已经存在同一路径的文件记录
+            existing = conn.execute(
+                text(
+                    """
+                    SELECT id, file_size
+                    FROM t_dm_dataset_files
+                    WHERE dataset_id = :dataset_id
+                      AND file_path = :file_path
+                      AND status = 'ACTIVE'
+                    LIMIT 1
+                    """,
+                ),
+                {"dataset_id": dataset_id, "file_path": annotations_path},
+            ).fetchone()
+
+            if existing:
+                # 已存在：仅更新文件大小及时间戳，避免重复插入
+                conn.execute(
+                    text(
+                        """
+                        UPDATE t_dm_dataset_files
+                        SET file_size = :file_size,
+                            updated_at = :updated_at,
+                            last_access_time = :last_access_time
+                        WHERE id = :id
+                        """,
+                    ),
+                    {
+                        "id": existing[0],
+                        "file_size": int(file_size),
+                        "updated_at": now,
+                        "last_access_time": now,
+                    },
+                )
+            else:
+                # 新文件：插入记录，并尽量更新 t_dm_datasets 的统计字段
+                new_id = str(uuid.uuid4())
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO t_dm_dataset_files
+                            (id, dataset_id, file_name, file_path, file_type, file_size, status, upload_time, created_at, updated_at)
+                        VALUES
+                            (:id, :dataset_id, :file_name, :file_path, :file_type, :file_size, 'ACTIVE', :now, :now, :now)
+                        """,
+                    ),
+                    {
+                        "id": new_id,
+                        "dataset_id": dataset_id,
+                        "file_name": file_name,
+                        "file_path": annotations_path,
+                        "file_type": ext,
+                        "file_size": int(file_size),
+                        "now": now,
+                    },
+                )
+
+                # 轻量更新数据集的文件数量和总大小统计
+                try:
+                    conn.execute(
+                        text(
+                            """
+                            UPDATE t_dm_datasets
+                            SET file_count = COALESCE(file_count, 0) + 1,
+                                size_bytes = COALESCE(size_bytes, 0) + :delta,
+                                updated_at = :now,
+                                status = 'ACTIVE'
+                            WHERE id = :dataset_id
+                            """,
+                        ),
+                        {
+                            "dataset_id": dataset_id,
+                            "delta": int(file_size),
+                            "now": now,
+                        },
+                    )
+                except Exception as e_ds:  # pragma: no cover - 统计更新失败不影响主流程
+                    logger.warning(
+                        "Failed to update dataset stats for {} when registering annotation file {}: {}",
+                        dataset_id,
+                        annotations_path,
+                        e_ds,
+                    )
+    except Exception as e:  # pragma: no cover - 防御性日志
+        logger.error(
+            "Failed to register annotation output file for dataset {} at {}: {}",
+            dataset_id,
+            annotations_path,
+            e,
+        )
+
+
 def _ensure_output_dir(output_dir: str) -> str:
-    """确保输出目录及其 images/、annotations/ 子目录存在。"""
+    """确保输出目录存在。
+
+    annotations 子目录由算子本身负责创建；这里不再为 images 创建额外目录，
+    以符合“自动标注不再单独保存 images” 的新设计。
+    """
 
     os.makedirs(output_dir, exist_ok=True)
-    os.makedirs(os.path.join(output_dir, "images"), exist_ok=True)
-    os.makedirs(os.path.join(output_dir, "annotations"), exist_ok=True)
     return output_dir
 
 
-def _create_output_dataset(
-    source_dataset_id: str,
-    source_dataset_name: str,
-    output_dataset_name: str,
-) -> Tuple[str, str]:
-    """为自动标注结果创建一个新的数据集并返回 (dataset_id, path)。"""
+def _trigger_forward_sync_to_label_studio(task_id: str) -> None:
+    """在任务完成后，自动调用后端接口，将检测结果推送到 Label Studio。
 
-    new_dataset_id = str(uuid.uuid4())
-    dataset_base_path = DEFAULT_OUTPUT_ROOT.rstrip("/") or "/dataset"
-    output_dir = os.path.join(dataset_base_path, new_dataset_id)
-
-    description = (
-        f"Auto annotations for dataset {source_dataset_name or source_dataset_id}"[:255]
-    )
-
-    sql = text(
-        """
-        INSERT INTO t_dm_datasets (id, name, description, dataset_type, path, status)
-        VALUES (:id, :name, :description, :dataset_type, :path, :status)
-        """
-    )
-    params = {
-        "id": new_dataset_id,
-        "name": output_dataset_name,
-        "description": description,
-        "dataset_type": "IMAGE",
-        "path": output_dir,
-        "status": "ACTIVE",
-    }
-
-    with SQLManager.create_connect() as conn:
-        conn.execute(sql, params)
-
-    return new_dataset_id, output_dir
-
-
-def _register_output_dataset(
-    task_id: str,
-    output_dataset_id: str,
-    output_dir: str,
-    output_dataset_name: str,
-    total_images: int,
-    *,
-    tags_by_filename: Optional[Dict[str, List[Dict[str, Any]]]] = None,
-) -> None:
-    """将自动标注结果注册到数据集。
-
-    如果多次为同一自动标注任务重复运行，将复用同一个输出数据集，并避免对
-    同一 dataset_id + file_name 插入重复记录，只为新文件追加记录。
+    该调用是“尽力而为”的：失败只记录日志，不影响任务本身的完成状态。
     """
 
-    images_dir = os.path.join(output_dir, "images")
-    if not os.path.isdir(images_dir):
-        logger.warning(
-            "Auto-annotation images directory not found for task {}: {}",
-            task_id,
-            images_dir,
+    if not AUTO_SYNC_ENABLED:
+        logger.info(
+            "Auto sync to Label Studio is disabled by env AUTO_ANNOTATION_SYNC_ENABLED",
         )
         return
 
-    image_files: List[Tuple[str, str, int]] = []
-    annotation_files: List[Tuple[str, str, int]] = []
-    total_size = 0
+    base_url = BACKEND_BASE_URL.rstrip("/")
+    url = f"{base_url}/api/annotation/auto/{task_id}/sync-label-studio"
 
-    for file_name in sorted(os.listdir(images_dir)):
-        file_path = os.path.join(images_dir, file_name)
-        if not os.path.isfile(file_path):
-            continue
-        try:
-            file_size = os.path.getsize(file_path)
-        except OSError:
-            file_size = 0
-        image_files.append((file_name, file_path, int(file_size)))
-        total_size += int(file_size)
-
-    annotations_dir = os.path.join(output_dir, "annotations")
-    if os.path.isdir(annotations_dir):
-        for file_name in sorted(os.listdir(annotations_dir)):
-            file_path = os.path.join(annotations_dir, file_name)
-            if not os.path.isfile(file_path):
-                continue
-            try:
-                file_size = os.path.getsize(file_path)
-            except OSError:
-                file_size = 0
-            annotation_files.append((file_name, file_path, int(file_size)))
-            total_size += int(file_size)
-
-    if not image_files:
-        logger.warning(
-            "No image files found in auto-annotation output for task {}: {}",
+    try:
+        payload = json.dumps({}).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=AUTO_SYNC_TIMEOUT_SECONDS) as resp:
+            status_code = resp.getcode()
+            body = resp.read().decode("utf-8", errors="ignore")
+        logger.info(
+            "Auto-annotation forward sync triggered for task {}: status={}, response={}",
             task_id,
-            images_dir,
+            status_code,
+            body,
         )
-        return
-
-    insert_file_sql = text(
-        """
-        INSERT INTO t_dm_dataset_files (
-            id, dataset_id, file_name, file_path, file_type, file_size, status, tags, tags_updated_at
-        ) VALUES (
-            :id, :dataset_id, :file_name, :file_path, :file_type, :file_size, :status, :tags, :tags_updated_at
+    except urllib.error.HTTPError as e:
+        logger.error(
+            "HTTP error when syncing auto-annotation task {} to Label Studio: status={}, reason={}",
+            task_id,
+            e.code,
+            e.reason,
         )
-        """
-    )
-    update_dataset_stat_sql = text(
-        """
-        UPDATE t_dm_datasets
-        SET file_count = COALESCE(file_count, 0) + :add_count,
-            size_bytes = COALESCE(size_bytes, 0) + :add_size
-        WHERE id = :dataset_id
-        """
-    )
-
-    with SQLManager.create_connect() as conn:
-        added_count = 0
-
-        # 预先查询已存在的文件名，避免重复插入
-        existing_names_sql = text(
-            """
-            SELECT file_name FROM t_dm_dataset_files WHERE dataset_id = :dataset_id
-            """
+    except Exception as e:  # pragma: no cover - 防御性日志
+        logger.error(
+            "Failed to sync auto-annotation task {} to Label Studio: {}",
+            task_id,
+            e,
         )
-        rows = conn.execute(existing_names_sql, {"dataset_id": output_dataset_id}).fetchall()
-        existing_names = {str(r[0]) for r in rows}
-
-        for file_name, file_path, file_size in image_files:
-            if file_name in existing_names:
-                continue
-            ext = os.path.splitext(file_name)[1].lstrip(".").upper() or None
-            file_tags = None
-            if tags_by_filename:
-                file_tags = tags_by_filename.get(file_name)
-            conn.execute(
-                insert_file_sql,
-                {
-                    "id": str(uuid.uuid4()),
-                    "dataset_id": output_dataset_id,
-                    "file_name": file_name,
-                    "file_path": file_path,
-                    "file_type": ext,
-                    "file_size": int(file_size),
-                    "status": "ACTIVE",
-                    "tags": json.dumps(file_tags, ensure_ascii=False) if file_tags else None,
-                    "tags_updated_at": datetime.utcnow() if file_tags else None,
-                },
-            )
-            added_count += 1
-            existing_names.add(file_name)
-
-        for file_name, file_path, file_size in annotation_files:
-            if file_name in existing_names:
-                continue
-            ext = os.path.splitext(file_name)[1].lstrip(".").upper() or None
-            conn.execute(
-                insert_file_sql,
-                {
-                    "id": str(uuid.uuid4()),
-                    "dataset_id": output_dataset_id,
-                    "file_name": file_name,
-                    "file_path": file_path,
-                    "file_type": ext,
-                    "file_size": int(file_size),
-                    "status": "ACTIVE",
-                    "tags": None,
-                    "tags_updated_at": None,
-                },
-            )
-            added_count += 1
-            existing_names.add(file_name)
-
-        if added_count > 0:
-            conn.execute(
-                update_dataset_stat_sql,
-                {
-                    "dataset_id": output_dataset_id,
-                    "add_count": added_count,
-                    "add_size": int(total_size),
-                },
-            )
-
-    logger.info(
-        "Registered auto-annotation output into dataset: dataset_id={}, name={}, added_files={}, added_size_bytes={}, task_id={}, output_dir={}",
-        output_dataset_id,
-        output_dataset_name,
-        len(image_files) + len(annotation_files),
-        total_size,
-        task_id,
-        output_dir,
-    )
 
 
 def _process_single_task(task: Dict[str, Any]) -> None:
@@ -579,64 +589,57 @@ def _process_single_task(task: Dict[str, Any]) -> None:
     else:
         all_files = _load_dataset_files(dataset_id)
 
-    # 优先复用任务已有的输出目录和对应数据集，避免重复创建结果数据集
+    # 优先复用任务已有的输出目录，避免重复创建或切换路径
     existing_output_path = (task.get("output_path") or "").strip() or None
-    output_dataset_id: Optional[str] = None
     output_dir: Optional[str] = None
 
     if existing_output_path:
         try:
             # 确保目录存在
             output_dir = _ensure_output_dir(existing_output_path)
-
-            # 根据路径查找已存在的数据集记录
-            find_dataset_sql = text(
-                """
-                SELECT id FROM t_dm_datasets
-                WHERE path = :path
-                ORDER BY created_at DESC
-                LIMIT 1
-                """
-            )
-            with SQLManager.create_connect() as conn:
-                row = conn.execute(find_dataset_sql, {"path": output_dir}).fetchone()
-            if row:
-                output_dataset_id = str(row[0])
-                logger.info(
-                    "Reuse existing output dataset for auto-annotation task: task_id={}, dataset_id={}, path={}",
-                    task_id,
-                    output_dataset_id,
-                    output_dir,
-                )
         except Exception as e:
             logger.error(
-                "Failed to reuse existing output dataset for task {}: {}",
+                "Failed to reuse existing output directory for task {}: {}",
                 task_id,
                 e,
             )
 
-    # 如果没有可复用的数据集，则创建新的结果数据集
-    if not output_dataset_id or not output_dir:
-        output_dataset_id, new_output_dir = _create_output_dataset(
-            source_dataset_id=dataset_id,
-            source_dataset_name=source_dataset_name,
-            output_dataset_name=output_dataset_name,
-        )
-        output_dir = _ensure_output_dir(new_output_dir)
+    # 如果没有可复用的输出目录，则基于“源数据集路径/annotations” 作为输出根目录
+    if not output_dir:
+        dataset_root = _get_dataset_root(dataset_id)
+        if not dataset_root:
+            logger.error(
+                "Failed to resolve dataset root for auto-annotation task {}: dataset_id={} not found or inactive",
+                task_id,
+                dataset_id,
+            )
+            _update_task_status(
+                task_id,
+                status="failed",
+                error_message="Dataset path not found for auto-annotation task",
+            )
+            return
+
+        # 直接使用源数据集下的 annotations 目录作为输出目录，
+        # YOLO 算子会在其中创建 JSON 文件。
+        base_annotations_dir = os.path.join(dataset_root, "annotations")
+        output_dir = _ensure_output_dir(base_annotations_dir)
 
     # 仅对“新选的数据”执行自动标注：
-    # 已经在输出目录 images/ 中存在对应文件名的，认为该任务已跑过，不再重复标注
-    existing_image_names: Set[str] = set()
-    images_dir = os.path.join(output_dir, "images")
-    if os.path.isdir(images_dir):
+    # 已经在输出目录中存在对应 JSON 文件的，认为该任务已跑过，不再重复标注
+    existing_stems: Set[str] = set()
+    annotations_dir = output_dir
+    if os.path.isdir(annotations_dir):
         try:
-            for name in os.listdir(images_dir):
-                if not os.path.isfile(os.path.join(images_dir, name)):
+            for name in os.listdir(annotations_dir):
+                file_path = os.path.join(annotations_dir, name)
+                if not os.path.isfile(file_path):
                     continue
-                existing_image_names.add(name)
+                stem, _ = os.path.splitext(name)
+                existing_stems.add(stem)
         except Exception as e:
             logger.error(
-                "Failed to list existing images for auto-annotation task {}: {}",
+                "Failed to list existing annotations for auto-annotation task {}: {}",
                 task_id,
                 e,
             )
@@ -645,7 +648,7 @@ def _process_single_task(task: Dict[str, Any]) -> None:
     files = [
         (file_id, file_path, file_name)
         for file_id, file_path, file_name in all_files
-        if os.path.basename(file_path) not in existing_image_names
+        if os.path.splitext(os.path.basename(file_path))[0] not in existing_stems
     ]
 
     total_images = len(files)
@@ -705,6 +708,27 @@ def _process_single_task(task: Dict[str, Any]) -> None:
             detected_total += len(detections)
             processed += 1
 
+            # 根据算子返回的 annotations_file 或约定路径，注册 JSON 文件到 t_dm_dataset_files
+            annotations_file = None
+            try:
+                annotations_file = (result or {}).get("annotations_file")
+            except Exception:
+                annotations_file = None
+
+            if not annotations_file:
+                base_name = os.path.basename(file_path)
+                stem, _ = os.path.splitext(base_name)
+                # 兼容两种目录结构：<output_dir>/annotations/<name>.json 或 <output_dir>/<name>.json
+                candidate1 = os.path.join(output_dir, "annotations", f"{stem}.json")
+                candidate2 = os.path.join(output_dir, f"{stem}.json")
+                if os.path.isfile(candidate1):
+                    annotations_file = candidate1
+                elif os.path.isfile(candidate2):
+                    annotations_file = candidate2
+
+            if annotations_file:
+                _register_annotation_output_file(dataset_id, annotations_file)
+
             # 基于检测结果生成标签（按类别去重），并写回源数据集文件
             file_tags = _build_file_tags_from_detections(detections)
             if file_tags:
@@ -761,22 +785,8 @@ def _process_single_task(task: Dict[str, Any]) -> None:
         output_dir,
     )
 
-    if output_dataset_name and output_dataset_id:
-        try:
-            _register_output_dataset(
-                task_id=task_id,
-                output_dataset_id=output_dataset_id,
-                output_dir=output_dir,
-                output_dataset_name=output_dataset_name,
-                total_images=total_images,
-                tags_by_filename=tags_by_filename,
-            )
-        except Exception as e:  # pragma: no cover - 防御性日志
-            logger.error(
-                "Failed to register auto-annotation output as dataset for task {}: {}",
-                task_id,
-                e,
-            )
+    # 任务完成后，自动触发一次前向同步，将检测结果推送到 Label Studio
+    _trigger_forward_sync_to_label_studio(task_id)
 
 
 def _worker_loop() -> None:


### PR DESCRIPTION
- Restrict annotation tasks to a single dataset while allowing multi-data selection
- Unify sync mechanism by removing forward/backward distinction and only syncing results back to the source dataset
- Simplify task actions by keeping primary actions (sync, edit) and moving low-frequency actions to a secondary menu
- Store auto-annotation results directly in the source dataset without creating additional image datasets
- Enable automatic sync of auto-annotation results to Label Studio upon completion
- Refactor annotation task creation UI to improve configuration clarity and data selection flow