### PR TITLE
feat(annotation): refine sync behavior and add annotation export option

### DIFF
--- a/backend/services/data-management-service/src/main/java/com/datamate/datamanagement/interfaces/dto/DatasetFileResponse.java
+++ b/backend/services/data-management-service/src/main/java/com/datamate/datamanagement/interfaces/dto/DatasetFileResponse.java
@@ -31,6 +31,8 @@ public class DatasetFileResponse {
     private String tags;
     /** 标签更新时间 */
     private LocalDateTime tagsUpdatedAt;
+    /** 文件元数据（包含标注信息等，JSON 字符串） */
+    private String metadata;
     /** 上传时间 */
     private LocalDateTime uploadTime;
     /** 最后更新时间 */

--- a/frontend/src/pages/DataAnnotation/Create/components/CreateAnnotationTaskDialog.tsx
+++ b/frontend/src/pages/DataAnnotation/Create/components/CreateAnnotationTaskDialog.tsx
@@ -120,6 +120,7 @@ export default function CreateAnnotationTask({
   const [selectedDataset, setSelectedDataset] = useState<Dataset | null>(null);
   const [imageFileCount, setImageFileCount] = useState(0);
   const [manualDatasetTypeFilter, setManualDatasetTypeFilter] = useState<DatasetType | undefined>(undefined);
+  const [manualAllowedExtensions, setManualAllowedExtensions] = useState<string[] | undefined>(undefined);
 
   useEffect(() => {
     if (!open) return;
@@ -178,6 +179,11 @@ export default function CreateAnnotationTask({
     setImageFileCount(count);
   }, [selectedFilesMap]);
 
+  const IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".bmp", ".gif", ".tiff", ".webp"];
+  const TEXT_EXTENSIONS = [".txt", ".md", ".csv", ".tsv", ".jsonl", ".log"];
+  const AUDIO_EXTENSIONS = [".wav", ".mp3", ".flac", ".aac", ".ogg", ".m4a", ".wma"];
+  const VIDEO_EXTENSIONS = [".mp4", ".avi", ".mov", ".mkv", ".flv", ".wmv", ".webm"];
+
   const mapTemplateDataTypeToDatasetType = (raw?: string): DatasetType | undefined => {
     if (!raw) return undefined;
     const v = String(raw).trim().toLowerCase();
@@ -214,6 +220,40 @@ export default function CreateAnnotationTask({
     if (imageTokens.has(v)) return DatasetType.IMAGE;
     if (audioTokens.has(v)) return DatasetType.AUDIO;
     if (videoTokens.has(v)) return DatasetType.VIDEO;
+
+    return undefined;
+  };
+
+  const getAllowedExtensionsForTemplateDataType = (raw?: string): string[] | undefined => {
+    if (!raw) return undefined;
+    const v = String(raw).trim().toLowerCase();
+
+    const textTokens = new Set<string>([
+      "text",
+      DataType.TEXT.toLowerCase(),
+      "文本",
+    ]);
+    const imageTokens = new Set<string>([
+      "image",
+      DataType.IMAGE.toLowerCase(),
+      "图像",
+      "图片",
+    ]);
+    const audioTokens = new Set<string>([
+      "audio",
+      DataType.AUDIO.toLowerCase(),
+      "音频",
+    ]);
+    const videoTokens = new Set<string>([
+      "video",
+      DataType.VIDEO.toLowerCase(),
+      "视频",
+    ]);
+
+    if (textTokens.has(v)) return TEXT_EXTENSIONS;
+    if (imageTokens.has(v)) return IMAGE_EXTENSIONS;
+    if (audioTokens.has(v)) return AUDIO_EXTENSIONS;
+    if (videoTokens.has(v)) return VIDEO_EXTENSIONS;
 
     return undefined;
   };
@@ -417,6 +457,9 @@ export default function CreateAnnotationTask({
                       const nextType = mapTemplateDataTypeToDatasetType(tpl?.dataType);
                       setManualDatasetTypeFilter(nextType);
 
+                      const nextExtensions = getAllowedExtensionsForTemplateDataType(tpl?.dataType);
+                      setManualAllowedExtensions(nextExtensions);
+
                       // 若当前已选数据集类型与模板不匹配，则清空当前选择
                       if (selectedDataset && nextType && selectedDataset.datasetType !== nextType) {
                         setSelectedDataset(null);
@@ -459,6 +502,7 @@ export default function CreateAnnotationTask({
                       }
                     }}
                     datasetTypeFilter={manualDatasetTypeFilter}
+                    allowedFileExtensions={manualAllowedExtensions}
                     singleDatasetOnly
                     disabled={!manualForm.getFieldValue("templateId")}
                   />
@@ -512,6 +556,7 @@ export default function CreateAnnotationTask({
                       autoForm.setFieldsValue({ datasetId: dataset?.id ?? "" });
                     }}
                     datasetTypeFilter={DatasetType.IMAGE}
+                    allowedFileExtensions={IMAGE_EXTENSIONS}
                     singleDatasetOnly
                   />
                   {selectedDataset && (

--- a/frontend/src/pages/DataAnnotation/annotation.api.ts
+++ b/frontend/src/pages/DataAnnotation/annotation.api.ts
@@ -79,6 +79,11 @@ export function importManualAnnotationFromLabelStudioUsingPost(
   return post(`/api/annotation/project/${mappingId}/sync-label-studio-back`, data);
 }
 
+// 手动标注：将 Label Studio 中的标注结果同步回数据库（更新 t_dm_dataset_files.tags/annotation）
+export function syncManualAnnotationToDatabaseUsingPost(mappingId: string) {
+  return post(`/api/annotation/project/${mappingId}/sync-db`);
+}
+
 export function downloadAutoAnnotationResultUsingGet(taskId: string) {
   return download(`/api/annotation/auto/${taskId}/download`);
 }
@@ -94,6 +99,11 @@ export function importAutoAnnotationFromLabelStudioUsingPost(
   data: { exportFormat?: string; fileName?: string }
 ) {
   return post(`/api/annotation/auto/${taskId}/sync-label-studio-back`, data);
+}
+
+// 自动标注：将 Label Studio 中的标注结果同步回数据库（更新 t_dm_dataset_files.tags/annotation）
+export function syncAutoAnnotationToDatabaseUsingPost(taskId: string) {
+  return post(`/api/annotation/auto/${taskId}/sync-db`);
 }
 
 // 查询自动标注任务关联的 Label Studio 项目

--- a/frontend/src/pages/DataManagement/Detail/components/Overview.tsx
+++ b/frontend/src/pages/DataManagement/Detail/components/Overview.tsx
@@ -657,6 +657,27 @@ export default function Overview({ dataset, filesOperation, fetchDataset }) {
                   <span>{previewFileDetail.description}</span>
                 </div>
               )}
+              <div>
+                <span className="text-gray-500">标注信息：</span>
+                <span>
+                  {(() => {
+                    const raw = (previewFileDetail?.annotation 
+                      ?? previewFileDetail?.metadata 
+                      ?? previewFileDetail?.tags) as any;
+                    if (!raw) return "-";
+
+                    if (typeof raw === "string") {
+                      return raw;
+                    }
+
+                    try {
+                      return JSON.stringify(raw);
+                    } catch {
+                      return "-";
+                    }
+                  })()}
+                </span>
+              </div>
             </div>
           </div>
         </div>

--- a/runtime/datamate-python/app/db/models/dataset_management.py
+++ b/runtime/datamate-python/app/db/models/dataset_management.py
@@ -61,6 +61,7 @@ class DatasetFiles(Base):
     check_sum = Column(String(64), nullable=True, comment="文件校验和")
     tags = Column(JSON, nullable=True, comment="文件标签信息")
     tags_updated_at = Column(TIMESTAMP, nullable=True, comment="标签最后更新时间")
+    annotation = Column(JSON, nullable=True, comment="完整标注结果（原始JSON）")
     dataset_filemetadata = Column("metadata", JSON, nullable=True, comment="文件元数据")
     status = Column(String(50), default='ACTIVE', comment="文件状态：ACTIVE/DELETED/PROCESSING")
     upload_time = Column(TIMESTAMP, server_default=func.current_timestamp(), comment="上传时间")

--- a/runtime/datamate-python/app/module/annotation/service/ls_annotation_sync.py
+++ b/runtime/datamate-python/app/module/annotation/service/ls_annotation_sync.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.db.models import DatasetFiles
+
+from ..client import LabelStudioClient
+
+logger = get_logger(__name__)
+
+
+class LSAnnotationSyncService:
+    """将 Label Studio 项目中的标注结果同步回 DM 数据库。
+
+    约定：
+    - Label Studio task.data 中包含由 SyncService 写入的 DM 元信息：
+      {"file_id": "...", "dataset_id": "...", "file_path": "...", "original_name": "..."}
+    - 对于每个 task，我们会：
+      * 读取该 task 的 annotations 列表；
+      * 结合 task.predictions 一并写入 t_dm_dataset_files.annotation；
+      * 从 annotations/predictions 的 result 字段中提取标签，写入 t_dm_dataset_files.tags；
+      * 更新时间戳 tags_updated_at。
+    """
+
+    def __init__(self, db: AsyncSession, ls_client: LabelStudioClient) -> None:
+        self.db = db
+        self.ls_client = ls_client
+
+    async def sync_project_annotations_to_dm(self, project_id: str) -> int:
+        """从指定 Label Studio 项目中同步所有任务的标注到 DM 文件表。
+
+        Args:
+            project_id: Label Studio 项目 ID（字符串形式）。
+
+        Returns:
+            成功更新的文件数量。
+        """
+        try:
+            page_size = getattr(settings, "ls_task_page_size", 1000)
+            result = await self.ls_client.get_project_tasks(
+                project_id=project_id,
+                page=None,
+                page_size=page_size,
+            )
+        except Exception as e:  # pragma: no cover - 防御性日志
+            logger.error("Failed to fetch tasks from Label Studio project %s: %s", project_id, e)
+            return 0
+
+        if not result:
+            logger.warning("No tasks returned for project %s when syncing annotations", project_id)
+            return 0
+
+        tasks: List[Dict[str, Any]] = result.get("tasks", [])  # type: ignore[assignment]
+        if not tasks:
+            logger.info("Project %s has no tasks to sync", project_id)
+            return 0
+
+        updated_files = 0
+
+        for task in tasks:
+            data: Dict[str, Any] = task.get("data") or {}
+            raw_file_id = data.get("file_id")
+            if not raw_file_id:
+                # 旧任务可能没有 DM file_id，跳过但记录日志
+                logger.debug(
+                    "Skip LS task %s because data.file_id is missing",
+                    task.get("id"),
+                )
+                continue
+
+            file_id = str(raw_file_id)
+
+            # 获取该任务的 annotations 列表
+            annotations: Optional[List[Dict[str, Any]]] = None
+            try:
+                annotations = await self.ls_client.get_task_annotations(int(task["id"]))  # type: ignore[arg-type]
+            except Exception as e:  # pragma: no cover
+                logger.error(
+                    "Failed to fetch annotations for LS task %s (file_id=%s): %s",
+                    task.get("id"),
+                    file_id,
+                    e,
+                )
+
+            predictions: List[Dict[str, Any]] = task.get("predictions") or []
+
+            annotation_payload: Dict[str, Any] = {
+                "task": {
+                    "id": task.get("id"),
+                    "project": task.get("project"),
+                    "data": data,
+                },
+                "annotations": annotations or [],
+                "predictions": predictions,
+            }
+
+            tags = self._extract_tags_from_results(
+                annotations or [],
+                predictions,
+            )
+
+            success = await self._update_dataset_file(file_id, tags, annotation_payload)
+            if success:
+                updated_files += 1
+
+        logger.info(
+            "Synced annotations from LS project %s to DM, updated %d files",
+            project_id,
+            updated_files,
+        )
+        return updated_files
+
+    async def _update_dataset_file(
+        self,
+        file_id: str,
+        tags: List[Dict[str, Any]],
+        annotation: Dict[str, Any],
+    ) -> bool:
+        """将提取出的 tags 与 annotation 写回 t_dm_dataset_files。
+
+        直接更新 DatasetFiles.tags / tags_updated_at / annotation 字段，
+        不走模板驱动的转换逻辑（模板转换在用户主动批量更新时使用）。
+        """
+        try:
+            result = await self.db.execute(
+                select(DatasetFiles).where(DatasetFiles.id == file_id)
+            )
+            record = result.scalar_one_or_none()
+
+            if not record:
+                logger.warning("Dataset file not found when syncing LS annotations: %s", file_id)
+                return False
+
+            update_time = datetime.utcnow()
+            record.tags = tags  # type: ignore[assignment]
+            record.tags_updated_at = update_time  # type: ignore[assignment]
+            # annotation 可能较大，但为 JSONB，直接整体覆盖
+            setattr(record, "annotation", annotation)
+
+            await self.db.commit()
+            await self.db.refresh(record)
+
+            logger.debug(
+                "Updated DM file %s with %d tags from LS annotations",
+                file_id,
+                len(tags),
+            )
+            return True
+
+        except Exception as e:  # pragma: no cover
+            logger.error("Failed to update DM file %s from LS annotations: %s", file_id, e)
+            try:
+                await self.db.rollback()
+            except Exception:
+                pass
+            return False
+
+    @staticmethod
+    def _extract_tags_from_results(
+        annotations: List[Dict[str, Any]],
+        predictions: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """从 annotations 和 predictions 的 result 字段中提取通用标签结构。
+
+        输出格式与 DM 前端当前解析逻辑兼容：
+        - 每个元素包含: id/type/from_name/values；
+        - 其中 values 是一个字典，键通常与 type 一致，例如 "rectanglelabels"；
+        - 前端通过 tag.values[tag.type] 提取字符串标签集合。
+        """
+
+        def iter_results() -> List[Dict[str, Any]]:
+            res: List[Dict[str, Any]] = []
+            for ann in annotations or []:
+                for item in ann.get("result", []) or []:
+                    if isinstance(item, dict):
+                        res.append(item)
+            for pred in predictions or []:
+                for item in pred.get("result", []) or []:
+                    if isinstance(item, dict):
+                        res.append(item)
+            return res
+
+        results = iter_results()
+        if not results:
+            return []
+
+        normalized: List[Dict[str, Any]] = []
+
+        for r in results:
+            r_type = r.get("type")
+            from_name = r.get("from_name") or r.get("fromName")
+            value_obj = r.get("value") or {}
+            if not isinstance(value_obj, dict):
+                continue
+
+            # 将 Label Studio 的 value 映射为 values，方便前端统一解析
+            values: Dict[str, Any] = {}
+            for key, v in value_obj.items():
+                values[key] = v
+
+            tag = {
+                "id": r.get("id"),
+                "type": r_type,
+                "from_name": from_name,
+                "values": values,
+            }
+            normalized.append(tag)
+
+        return normalized

--- a/runtime/datamate-python/app/module/dataset/schema/dataset_file.py
+++ b/runtime/datamate-python/app/module/dataset/schema/dataset_file.py
@@ -15,8 +15,9 @@ class DatasetFileResponse(BaseModel):
     description: Optional[str] = Field(None, description="文件描述")
     uploadedBy: Optional[str] = Field(None, description="上传者")
     lastAccessTime: Optional[datetime] = Field(None, description="最后访问时间")
-    tags: Optional[List[Dict[str, Any]]] = Field(None, description="文件标签/标注信息")
+    tags: Optional[List[Dict[str, Any]]] = Field(None, description="文件标签/标注信息（简要结构）")
     tags_updated_at: Optional[datetime] = Field(None, description="标签最后更新时间", alias="tagsUpdatedAt")
+    annotation: Optional[Dict[str, Any]] = Field(None, description="完整标注结果（原始JSON）")
 
 class PagedDatasetFileResponse(BaseModel):
     """DM服务分页文件响应模型"""

--- a/runtime/datamate-python/app/module/dataset/service/service.py
+++ b/runtime/datamate-python/app/module/dataset/service/service.py
@@ -116,7 +116,8 @@ class Service:
                     uploadedBy=None,
                     lastAccessTime=f.last_access_time,  # type: ignore
                     tags=f.tags,  # type: ignore
-                    tags_updated_at=f.tags_updated_at  # type: ignore
+                    tags_updated_at=f.tags_updated_at,  # type: ignore
+                    annotation=getattr(f, "annotation", None),  # type: ignore
                 )
                 for f in files
             ]

--- a/runtime/ops/annotation/image_object_detection_bounding_box/process.py
+++ b/runtime/ops/annotation/image_object_detection_bounding_box/process.py
@@ -180,18 +180,17 @@ class ImageObjectDetectionBoundingBox(Mapper):
         else:
             output_dir = os.path.dirname(image_path)
         
-        # 创建输出子目录：仅保留 annotations 目录，不再额外保存标注图像，
-        # 以减少冗余占用；检测结果将直接写入 JSON 文件。
-        annotations_dir = os.path.join(output_dir, "annotations")
-        os.makedirs(annotations_dir, exist_ok=True)
-        
+        # 创建 / 使用输出目录：直接在 output_dir 下保存 JSON，
+        # 约定最终路径为 <output_dir>/<image_stem>.json，避免 "annotations/annotations" 嵌套。
+        os.makedirs(output_dir, exist_ok=True)
+
         # 保持原始文件名（不添加后缀），确保一一对应
         base_name = os.path.basename(image_path)
         name_without_ext = os.path.splitext(base_name)[0]
-        
+
         # 保存标注 JSON（文件名与图像对应）
         json_filename = f"{name_without_ext}.json"
-        json_path = os.path.join(annotations_dir, json_filename)
+        json_path = os.path.join(output_dir, json_filename)
         with open(json_path, "w", encoding="utf-8") as f:
             json.dump(annotations, f, indent=2, ensure_ascii=False)
         

--- a/scripts/db/data-management-init.sql
+++ b/scripts/db/data-management-init.sql
@@ -85,6 +85,7 @@ CREATE TABLE IF NOT EXISTS t_dm_dataset_files (
     check_sum VARCHAR(64),
     tags JSONB,
     tags_updated_at TIMESTAMP,
+    annotation JSONB,
     metadata JSONB,
     status VARCHAR(50) DEFAULT 'ACTIVE',
     upload_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -101,8 +102,9 @@ COMMENT ON COLUMN t_dm_dataset_files.file_path IS '文件路径';
 COMMENT ON COLUMN t_dm_dataset_files.file_type IS '文件格式：JPG/PNG/DCM/TXT等';
 COMMENT ON COLUMN t_dm_dataset_files.file_size IS '文件大小(字节)';
 COMMENT ON COLUMN t_dm_dataset_files.check_sum IS '文件校验和';
-COMMENT ON COLUMN t_dm_dataset_files.tags IS '文件标签信息';
+COMMENT ON COLUMN t_dm_dataset_files.tags IS '文件标签信息（结构化标签/标注概要）';
 COMMENT ON COLUMN t_dm_dataset_files.tags_updated_at IS '标签最后更新时间';
+COMMENT ON COLUMN t_dm_dataset_files.annotation IS '完整标注结果（原始JSON）';
 COMMENT ON COLUMN t_dm_dataset_files.metadata IS '文件元数据';
 COMMENT ON COLUMN t_dm_dataset_files.status IS '文件状态：ACTIVE/DELETED/PROCESSING';
 COMMENT ON COLUMN t_dm_dataset_files.upload_time IS '上传时间';


### PR DESCRIPTION
- Update annotation sync action to store annotation results as tags in data metadata
- Add export option in secondary menu to save full annotation results to source annotation directory