### PR TITLE
fix: updates the endpoint URL for the ME provider

### DIFF
--- a/runtime/datamate-python/app/module/system/service/models_service.py
+++ b/runtime/datamate-python/app/module/system/service/models_service.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 
 # 固定厂商列表
 PROVIDERS = [
-    ProviderItem(provider="ModelEngine", baseUrl="http://localhost:9981"),
+    ProviderItem(provider="ModelEngine", baseUrl="http://nginxservice/open/router/v1"),
     ProviderItem(provider="Ollama", baseUrl="http://localhost:11434"),
     ProviderItem(provider="OpenAI", baseUrl="https://api.openai.com/v1"),
     ProviderItem(provider="DeepSeek", baseUrl="https://api.deepseek.com/v1"),


### PR DESCRIPTION
This pull request updates the endpoint URL for the `ModelEngine` provider in the `PROVIDERS` list to route requests through a different service.

- Provider configuration update:
  * Changed the `baseUrl` for the `ModelEngine` provider from `http://localhost:9981` to `http://nginxservice/open/router/v1` in `service/models_service.py` to support routing through `nginxservice`.…SuccessResponse