### PR TITLE
fix: Fixed the problem that multiple labels cannot be selected when creating annotation tasks in text multi-label templates.

### DIFF
--- a/runtime/datamate-python/app/module/annotation/schema/template.py
+++ b/runtime/datamate-python/app/module/annotation/schema/template.py
@@ -14,6 +14,7 @@ class LabelDefinition(BaseModel):
     options: Optional[List[str]] = Field(None, description="选项列表（用于choices类型）")
     labels: Optional[List[str]] = Field(None, description="标签列表（用于rectanglelabels等类型）")
     required: bool = Field(False, description="是否必填")
+    choice: Optional[str] = Field(None, description="选项设置")
     description: Optional[str] = Field(None, description="标签描述")
     
     model_config = ConfigDict(populate_by_name=True)

--- a/runtime/datamate-python/app/module/annotation/service/template.py
+++ b/runtime/datamate-python/app/module/annotation/service/template.py
@@ -55,7 +55,10 @@ class AnnotationTemplateService:
             # 添加可选属性
             if label.required:
                 label_attrs.append('required="true"')
-            
+
+            if label.choice:
+                label_attrs.append(f'choice="{label.choice}"')
+
             tag_type = label.type.capitalize() if label.type else "Choices"
             
             # 检查是否需要子元素


### PR DESCRIPTION
<img width="2583" height="598" alt="image" src="https://github.com/user-attachments/assets/0e4a497f-7cb9-48d7-917f-364c2b8d1b5c" />
