### PR TITLE
fix: add ffmpeg to runtime image

### DIFF
--- a/scripts/images/runtime/Dockerfile
+++ b/scripts/images/runtime/Dockerfile
@@ -3,7 +3,18 @@ FROM ghcr.io/astral-sh/uv:python3.11-bookworm
 RUN --mount=type=cache,target=/var/cache/apt \
     --mount=type=cache,target=/var/lib/apt \
     apt update \
-    && apt install -y libgl1 libglib2.0-0 vim libmagic1 libreoffice dos2unix swig poppler-utils tesseract-ocr
+    && apt install -y --no-install-recommends \
+        libgl1 \
+        libglib2.0-0 \
+        vim \
+        libmagic1 \
+        libreoffice \
+        dos2unix \
+        swig \
+        poppler-utils \
+        tesseract-ocr \
+        ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /home/models \
     && wget https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_doc_ori_infer.tar \


### PR DESCRIPTION
## Summary
This PR adds system-level ffmpeg support to the runtime image.

## Changes
- adds `ffmpeg` to `scripts/images/runtime/Dockerfile`
- `ffprobe` is provided by the ffmpeg package
- keeps the change limited to the runtime Dockerfile

## Reason
Video operators such as keyframe extraction require `ffmpeg`/`ffprobe` in the runtime container.