### PR TITLE
fix: add missing import for select and DatasetFiles in replace endpoint

### DIFF
--- a/runtime/datamate-python/app/module/annotation/interface/task.py
+++ b/runtime/datamate-python/app/module/annotation/interface/task.py
@@ -351,6 +351,9 @@ async def replace_file_tags(
     """
     service = DatasetManagementService(db)
 
+    from sqlalchemy.future import select
+    from app.db.models import DatasetFiles
+
     result = await db.execute(
         select(DatasetFiles).where(DatasetFiles.id == file_id)
     )


### PR DESCRIPTION
## Summary

Fix missing import in the newly added `PUT /{file_id}/replace` endpoint.

## Problem

The endpoint was missing the required imports:
- `from sqlalchemy.future import select`
- `from app.db.models import DatasetFiles`

This caused a `NameError: name 'select' is not defined` when calling the API.

## Solution

Added the missing imports inside the endpoint function, following the same pattern as the existing `update_file_tags` endpoint.