### PR TITLE
feat: add interactive node configuration for dedicated DataMate nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,8 @@ help:
 	@echo ""
 	@echo "Utility Commands:"
 	@echo "  make create-namespace          Create Kubernetes namespace"
+	@echo "  make node-setup               Configure dedicated nodes interactively"
+	@echo "  make node-cleanup             Remove node labels and taints"
 	@echo "  make help                      Show this help message"
 	@echo ""
 	@echo "Examples:"
@@ -193,6 +195,26 @@ build: database-docker-build gateway-docker-build backend-docker-build frontend-
 .PHONY: create-namespace
 create-namespace:
 	kubectl get namespace $(NAMESPACE) > /dev/null 2>&1 || kubectl create namespace $(NAMESPACE)
+
+# ========== Node Setup/Cleanup Targets ==========
+
+.PHONY: node-setup
+node-setup:
+	@echo "Configure dedicated nodes for DataMate deployment?"
+	@echo "This will apply labels and optional taints to selected nodes."
+	@echo "1. Yes - Configure nodes interactively"
+	@echo "2. No - Use default scheduling"
+	@echo -n "Enter choice (default: 2): "
+	@read NODE_SETUP_CHOICE; \
+	if [ "$$NODE_SETUP_CHOICE" = "1" ]; then \
+		chmod +x scripts/k8s/node-setup.sh; \
+		./scripts/k8s/node-setup.sh --namespace $(NAMESPACE); \
+	fi
+
+.PHONY: node-cleanup
+node-cleanup:
+	@chmod +x scripts/k8s/node-cleanup.sh
+	@./scripts/k8s/node-cleanup.sh --namespace $(NAMESPACE)
 
 # ========== Generic Install/Uninstall Targets (Redirect to prompt-installer) ==========
 
@@ -342,8 +364,18 @@ VALID_K8S_TARGETS := datamate deer-flow milvus label-studio data-juicer mineru m
 	elif [ "$*" = "mineru-310P" ]; then \
 		kubectl apply -f deployment/kubernetes/mineru/deploy-310.yaml -n $(NAMESPACE); \
 	elif [ "$*" = "datamate" ]; then \
+		echo ""; \
+		chmod +x scripts/k8s/node-setup.sh; \
+		./scripts/k8s/node-setup.sh --namespace $(NAMESPACE); \
+		if [ -f /tmp/datamate-helm-args.sh ]; then \
+			source /tmp/datamate-helm-args.sh; \
+		fi; \
 		kubectl apply -f deployment/kubernetes/sealed-secrets/datamate.yaml; \
-		helm upgrade datamate deployment/helm/datamate/ -n $(NAMESPACE) --install --set global.image.repository=$(REGISTRY) --set public.secrets.create=false; \
+		if [ -n "$$HELM_NODE_SELECTOR_ARGS" ] || [ -n "$$HELM_TOLERATIONS_ARGS" ]; then \
+			helm upgrade datamate deployment/helm/datamate/ -n $(NAMESPACE) --install --set global.image.repository=$(REGISTRY) --set public.secrets.create=false $$HELM_NODE_SELECTOR_ARGS $$HELM_TOLERATIONS_ARGS; \
+		else \
+			helm upgrade datamate deployment/helm/datamate/ -n $(NAMESPACE) --install --set global.image.repository=$(REGISTRY) --set public.secrets.create=false; \
+		fi; \
 	elif [ "$*" = "deer-flow" ]; then \
 		cp runtime/deer-flow/.env deployment/helm/deer-flow/charts/public/.env; \
 		cp runtime/deer-flow/conf.yaml deployment/helm/deer-flow/charts/public/conf.yaml; \
@@ -371,6 +403,12 @@ VALID_K8S_TARGETS := datamate deer-flow milvus label-studio data-juicer mineru m
 	elif [ "$*" = "mineru-310P" ]; then \
 		kubectl delete -f deployment/kubernetes/mineru/deploy-310.yaml -n $(NAMESPACE); \
 	elif [ "$*" = "datamate" ]; then \
+		echo ""; \
+		echo "Remove node configuration (labels/taints)? (y/n) [n]"; \
+		read -p "> " CLEANUP_NODES; \
+		if [ "$$CLEANUP_NODES" = "y" ] || [ "$$CLEANUP_NODES" = "Y" ]; then \
+			$(MAKE) node-cleanup; \
+		fi; \
 		helm uninstall datamate -n $(NAMESPACE) --ignore-not-found; \
 	elif [ "$*" = "deer-flow" ]; then \
 		helm uninstall deer-flow -n $(NAMESPACE) --ignore-not-found; \

--- a/Makefile
+++ b/Makefile
@@ -371,11 +371,12 @@ VALID_K8S_TARGETS := datamate deer-flow milvus label-studio data-juicer mineru m
 			source /tmp/datamate-helm-args.sh; \
 		fi; \
 		kubectl apply -f deployment/kubernetes/sealed-secrets/datamate.yaml; \
-		if [ -n "$$HELM_NODE_SELECTOR_ARGS" ] || [ -n "$$HELM_TOLERATIONS_ARGS" ]; then \
+		if [ -n "$$HELM_NODE_SELECTOR_ARGS" ] || [ -n "$$$HELM_TOLERATIONS_ARGS" ]; then \
 			helm upgrade datamate deployment/helm/datamate/ -n $(NAMESPACE) --install --set global.image.repository=$(REGISTRY) --set public.secrets.create=false $$HELM_NODE_SELECTOR_ARGS $$HELM_TOLERATIONS_ARGS; \
 		else \
 			helm upgrade datamate deployment/helm/datamate/ -n $(NAMESPACE) --install --set global.image.repository=$(REGISTRY) --set public.secrets.create=false; \
 		fi; \
+		rm -f /tmp/datamate-helm-args.sh; \
 	elif [ "$*" = "deer-flow" ]; then \
 		cp runtime/deer-flow/.env deployment/helm/deer-flow/charts/public/.env; \
 		cp runtime/deer-flow/conf.yaml deployment/helm/deer-flow/charts/public/conf.yaml; \

--- a/deployment/helm/datamate/Chart.yaml
+++ b/deployment/helm/datamate/Chart.yaml
@@ -24,6 +24,8 @@ version: 0.0.1
 appVersion: "0.0.1"
 
 dependencies:
+  - name: public
+    version: 0.0.1
   - name: backend
     version: 0.0.1
   - name: gateway

--- a/deployment/helm/datamate/charts/kuberay-operator/values.yaml
+++ b/deployment/helm/datamate/charts/kuberay-operator/values.yaml
@@ -214,6 +214,12 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
 service:
   # -- Service type.
   type: ClusterIP

--- a/deployment/helm/datamate/values.yaml
+++ b/deployment/helm/datamate/values.yaml
@@ -4,6 +4,18 @@
 
 global:
   namespace: datamate
+  # Default nodeSelector for all pods in datamate namespace
+  # Override in subchart values.yaml if needed for specific services
+  nodeSelector: {}
+    # Example: To schedule pods on nodes with specific labels
+    # node-role.kubernetes.io/datamate: "true"
+  # Default tolerations for all pods (used when nodes have taints)
+  tolerations: []
+    # Example: To tolerate taints on dedicated nodes
+    # - key: "node-role.kubernetes.io/datamate"
+    #   operator: "Equal"
+    #   value: "true"
+    #   effect: "NoSchedule"
   image:
     repository: "ghcr.io/modelengine-group/"
     pullPolicy: "IfNotPresent"
@@ -71,6 +83,8 @@ operatorVolume: &operatorVolume
     claimName: datamate-operator-pvc
 
 database:
+  nodeSelector: {}
+  tolerations: []
   initContainers:
     - name: init-chown
       imagePullPolicy: IfNotPresent
@@ -109,6 +123,8 @@ database:
       subPath: database
 
 backend:
+  nodeSelector: {}
+  tolerations: []
   securityContext:
     capabilities:
       add:
@@ -144,6 +160,8 @@ backend:
       mountPath: /operators
 
 backend-python:
+  nodeSelector: {}
+  tolerations: []
   env:
     - name: PGSQL_HOST
       value: "datamate-database"
@@ -186,6 +204,8 @@ backend-python:
       mountPath: /operators
 
 gateway:
+  nodeSelector: {}
+  tolerations: []
   env:
     - name: JWT_SECRET
       valueFrom:
@@ -204,6 +224,8 @@ gateway:
       subPath: gateway
 
 frontend:
+  nodeSelector: {}
+  tolerations: []
   service:
     type: NodePort
     nodePort: 30000
@@ -234,6 +256,8 @@ frontend:
       mountPath: /cert
 
 runtime:
+  nodeSelector: {}
+  tolerations: []
   enabled: false
   args: &runtimeArgs
     - python
@@ -279,6 +303,8 @@ runtime:
 ray-cluster:
   enabled: true
   head:
+    nodeSelector: {}
+    tolerations: []
     enableInTreeAutoscaling: true
     autoscalerOptions:
       upscalingMode: Default
@@ -348,6 +374,8 @@ ray-cluster:
           - containerPort: 8081
         volumeMounts: *runtimeVolumeMounts
   worker:
+    nodeSelector: {}
+    tolerations: []
     containerEnv:
       - name: RAY_DEDUP_LOGS
         value: "0"
@@ -398,6 +426,8 @@ ray-cluster:
         subPath: site-packages
   additionalWorkerGroups:
     npuGroup:
+      nodeSelector: {}
+      tolerations: []
       disabled: false
       replicas: 0
       minReplicas: 0
@@ -460,6 +490,8 @@ ray-cluster:
         - mountPath: /usr/local/Ascend
           name: ascend
     gpuGroup:
+      nodeSelector: {}
+      tolerations: []
       disabled: false
       replicas: 0
       minReplicas: 0

--- a/deployment/kubernetes/data-juicer/deploy.yaml
+++ b/deployment/kubernetes/data-juicer/deploy.yaml
@@ -17,6 +17,13 @@ spec:
         app: datamate
         tier: data-juicer
     spec:
+      nodeSelector: {}
+        # Example: node-role.kubernetes.io/datamate: "true"
+      tolerations: []
+        # Example: - key: "node-role.kubernetes.io/datamate"
+        #             operator: "Equal"
+        #             value: "true"
+        #             effect: "NoSchedule"
       containers:
         - name: data-juicer
           image: datajuicer/data-juicer:v1.4.4
@@ -42,8 +49,6 @@ spec:
             - name: log-volume
               mountPath: /var/log/datamate/data-juicer
               subPath: data-juicer
-            - name: flow-volume
-              mountPath: /flow
       volumes:
         - name: dataset-volume
           persistentVolumeClaim:

--- a/deployment/kubernetes/mineru/deploy-310.yaml
+++ b/deployment/kubernetes/mineru/deploy-310.yaml
@@ -17,6 +17,13 @@ spec:
         app: datamate
         tier: mineru
     spec:
+      nodeSelector: {}
+        # Example: node-role.kubernetes.io/datamate: "true"
+      tolerations: []
+        # Example: - key: "node-role.kubernetes.io/datamate"
+        #             operator: "Equal"
+        #             value: "true"
+        #             effect: "NoSchedule"
       containers:
         - name: mineru
           image: datamate-mineru

--- a/deployment/kubernetes/mineru/deploy-910.yaml
+++ b/deployment/kubernetes/mineru/deploy-910.yaml
@@ -17,6 +17,13 @@ spec:
         app: datamate
         tier: mineru
     spec:
+      nodeSelector: {}
+        # Example: node-role.kubernetes.io/datamate: "true"
+      tolerations: []
+        # Example: - key: "node-role.kubernetes.io/datamate"
+        #             operator: "Equal"
+        #             value: "true"
+        #             effect: "NoSchedule"
       containers:
         - name: mineru
           image: datamate-mineru

--- a/scripts/k8s/node-cleanup.sh
+++ b/scripts/k8s/node-cleanup.sh
@@ -17,6 +17,7 @@ NC='\033[0m' # No Color
 
 # Default values
 DRY_RUN=false
+NAMESPACE="datamate"
 SELECTED_NODES_FILE="/tmp/datamate-selected-nodes.txt"
 LABEL_KEY="node-role.kubernetes.io/datamate"
 LABEL_VALUE="true"
@@ -26,6 +27,10 @@ TAINT_APPLIED=false
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
+        --namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
         --dry-run)
             DRY_RUN=true
             shift

--- a/scripts/k8s/node-cleanup.sh
+++ b/scripts/k8s/node-cleanup.sh
@@ -18,11 +18,9 @@ NC='\033[0m' # No Color
 # Default values
 DRY_RUN=false
 NAMESPACE="datamate"
-SELECTED_NODES_FILE="/tmp/datamate-selected-nodes.txt"
 LABEL_KEY="node-role.kubernetes.io/datamate"
 LABEL_VALUE="true"
 TAINT_EFFECT="NoSchedule"
-TAINT_APPLIED=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -72,25 +70,22 @@ if [ "$PROVIDED_NODES" != "" ]; then
     # Use provided nodes
     IFS=',' read -ra SELECTED_NODES <<< "$PROVIDED_NODES"
 else
-    # Try to read from saved file
-    if [ -f "$SELECTED_NODES_FILE" ]; then
-        echo -e "${YELLOW}Reading saved configuration from $SELECTED_NODES_FILE${NC}"
-        source "$SELECTED_NODES_FILE"
-        SELECTED_NODES_STR=$(head -n 1 "$SELECTED_NODES_FILE")
-        IFS=' ' read -ra SELECTED_NODES <<< "$SELECTED_NODES_STR"
-    else
-        # Find nodes with the datamate label
-        echo -e "${YELLOW}Finding nodes with $LABEL_KEY label...${NC}"
-        NODES=$(kubectl get nodes -l "$LABEL_KEY=$LABEL_VALUE" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
-        if [ "$NODES" = "" ]; then
-            echo -e "${YELLOW}No nodes found with $LABEL_KEY label.${NC}"
-            exit 0
-        fi
-        SELECTED_NODES=()
-        for NODE in $NODES; do
-            SELECTED_NODES+=("$NODE")
-        done
+    # Find nodes with the datamate label directly from Kubernetes
+    echo -e "${YELLOW}Finding nodes with $LABEL_KEY=$LABEL_VALUE label...${NC}"
+    NODES=$(kubectl get nodes -l "$LABEL_KEY=$LABEL_VALUE" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+
+    if [ -z "$NODES" ]; then
+        echo -e "${GREEN}No nodes found with $LABEL_KEY=$LABEL_VALUE label.${NC}"
+        echo -e "${YELLOW}Cleanup not needed - no nodes were labeled.${NC}"
+        exit 0
     fi
+
+    SELECTED_NODES=()
+    while IFS= read -r NODE; do
+        if [ -n "$NODE" ]; then
+            SELECTED_NODES+=("$NODE")
+        fi
+    done <<< "$NODES"
 fi
 
 if [ ${#SELECTED_NODES[@]} -eq 0 ]; then
@@ -106,7 +101,18 @@ done
 echo ""
 echo -e "${BLUE}Summary:${NC}"
 echo "  Label to remove: $LABEL_KEY"
-if [ "$TAINT_APPLIED" = true ]; then
+
+# Check if any node has the taint
+HAS_TAINTS=false
+for NODE in "${SELECTED_NODES[@]}"; do
+    TAINT_COUNT=$(kubectl get node "$NODE" -o jsonpath='{range .spec.taints[*]}{.key}{"\n"}{end}' | grep -c "^${LABEL_KEY}$" || echo "0")
+    if [ "$TAINT_COUNT" -gt 0 ]; then
+        HAS_TAINTS=true
+        break
+    fi
+done
+
+if [ "$HAS_TAINTS" = true ]; then
     echo "  Taint to remove: $LABEL_KEY=$LABEL_VALUE:$TAINT_EFFECT"
 fi
 echo ""
@@ -132,25 +138,30 @@ for NODE in "${SELECTED_NODES[@]}"; do
     fi
 done
 
-# Remove taints if they were applied
-if [ "$TAINT_APPLIED" = true ] || [ "$PROVIDED_NODES" != "" ]; then
-    for NODE in "${SELECTED_NODES[@]}"; do
+# Remove taints (check if node has the taint)
+for NODE in "${SELECTED_NODES[@]}"; do
+    # Check if node has the taint
+    HAS_TAINT=$(kubectl get node "$NODE" -o jsonpath='{range .spec.taints[*]}{.key}{"\n"}{end}' | grep -c "^${LABEL_KEY}$" || echo "0")
+
+    if [ "$HAS_TAINT" -gt 0 ]; then
         if [ "$DRY_RUN" = true ]; then
             echo "[DRY-RUN] kubectl taint node $NODE $LABEL_KEY=$LABEL_VALUE:$TAINT_EFFECT-"
         else
             kubectl taint node "$NODE" "$LABEL_KEY=$LABEL_VALUE:$TAINT_EFFECT-" --overwrite || true
             echo -e "  ${GREEN}✓${NC} Removed taint from $NODE"
         fi
-    done
-fi
+    else
+        echo -e "  ${YELLOW}○${NC} No taint to remove from $NODE"
+    fi
+done
 
 echo ""
 echo -e "${GREEN}Cleanup complete!${NC}"
 
-# Remove the saved file
-if [ -f "$SELECTED_NODES_FILE" ]; then
-    rm "$SELECTED_NODES_FILE"
-    echo -e "${GREEN}Removed $SELECTED_NODES_FILE${NC}"
+# Clean up Helm args temp file if it exists
+if [ -f /tmp/datamate-helm-args.sh ]; then
+    rm /tmp/datamate-helm-args.sh
+    echo -e "${GREEN}Removed /tmp/datamate-helm-args.sh${NC}"
 fi
 
 exit 0

--- a/scripts/k8s/node-cleanup.sh
+++ b/scripts/k8s/node-cleanup.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+#
+# DataMate Node Cleanup Script
+# Remove labels and taints from nodes that were configured for DataMate deployment
+#
+# Usage: ./node-cleanup.sh [--dry-run] [--nodes NODE1,NODE2]
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default values
+DRY_RUN=false
+SELECTED_NODES_FILE="/tmp/datamate-selected-nodes.txt"
+LABEL_KEY="node-role.kubernetes.io/datamate"
+LABEL_VALUE="true"
+TAINT_EFFECT="NoSchedule"
+TAINT_APPLIED=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --nodes)
+            PROVIDED_NODES="$2"
+            shift 2
+            ;;
+        --label-key)
+            LABEL_KEY="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+echo -e "${BLUE}=====================================${NC}"
+echo -e "${BLUE}  DataMate Node Cleanup${NC}"
+echo -e "${BLUE}=====================================${NC}"
+echo ""
+
+# Check if kubectl is available
+if ! command -v kubectl &> /dev/null; then
+    echo -e "${RED}Error: kubectl is not installed${NC}"
+    exit 1
+fi
+
+# Check if connected to cluster
+if ! kubectl cluster-info &> /dev/null; then
+    echo -e "${RED}Error: Cannot connect to Kubernetes cluster${NC}"
+    exit 1
+fi
+
+# Determine nodes to clean up
+if [ "$PROVIDED_NODES" != "" ]; then
+    # Use provided nodes
+    IFS=',' read -ra SELECTED_NODES <<< "$PROVIDED_NODES"
+else
+    # Try to read from saved file
+    if [ -f "$SELECTED_NODES_FILE" ]; then
+        echo -e "${YELLOW}Reading saved configuration from $SELECTED_NODES_FILE${NC}"
+        source "$SELECTED_NODES_FILE"
+        SELECTED_NODES_STR=$(head -n 1 "$SELECTED_NODES_FILE")
+        IFS=' ' read -ra SELECTED_NODES <<< "$SELECTED_NODES_STR"
+    else
+        # Find nodes with the datamate label
+        echo -e "${YELLOW}Finding nodes with $LABEL_KEY label...${NC}"
+        NODES=$(kubectl get nodes -l "$LABEL_KEY=$LABEL_VALUE" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+        if [ "$NODES" = "" ]; then
+            echo -e "${YELLOW}No nodes found with $LABEL_KEY label.${NC}"
+            exit 0
+        fi
+        SELECTED_NODES=()
+        for NODE in $NODES; do
+            SELECTED_NODES+=("$NODE")
+        done
+    fi
+fi
+
+if [ ${#SELECTED_NODES[@]} -eq 0 ]; then
+    echo -e "${YELLOW}No nodes to clean up.${NC}"
+    exit 0
+fi
+
+echo -e "${GREEN}Nodes to clean up:${NC}"
+for NODE in "${SELECTED_NODES[@]}"; do
+    echo "  - $NODE"
+done
+
+echo ""
+echo -e "${BLUE}Summary:${NC}"
+echo "  Label to remove: $LABEL_KEY"
+if [ "$TAINT_APPLIED" = true ]; then
+    echo "  Taint to remove: $LABEL_KEY=$LABEL_VALUE:$TAINT_EFFECT"
+fi
+echo ""
+
+read -p "Remove labels and taints? (y/n) [y]: " CONFIRM
+CONFIRM=${CONFIRM:-y}
+
+if [ "$CONFIRM" != "y" ] && [ "$CONFIRM" != "Y" ]; then
+    echo -e "${YELLOW}Cancelled.${NC}"
+    exit 0
+fi
+
+echo ""
+echo -e "${GREEN}Removing configuration...${NC}"
+
+# Remove labels from selected nodes
+for NODE in "${SELECTED_NODES[@]}"; do
+    if [ "$DRY_RUN" = true ]; then
+        echo "[DRY-RUN] kubectl label node $NODE $LABEL_KEY-"
+    else
+        kubectl label node "$NODE" "$LABEL_KEY-" --overwrite
+        echo -e "  ${GREEN}✓${NC} Removed label from $NODE"
+    fi
+done
+
+# Remove taints if they were applied
+if [ "$TAINT_APPLIED" = true ] || [ "$PROVIDED_NODES" != "" ]; then
+    for NODE in "${SELECTED_NODES[@]}"; do
+        if [ "$DRY_RUN" = true ]; then
+            echo "[DRY-RUN] kubectl taint node $NODE $LABEL_KEY=$LABEL_VALUE:$TAINT_EFFECT-"
+        else
+            kubectl taint node "$NODE" "$LABEL_KEY=$LABEL_VALUE:$TAINT_EFFECT-" --overwrite || true
+            echo -e "  ${GREEN}✓${NC} Removed taint from $NODE"
+        fi
+    done
+fi
+
+echo ""
+echo -e "${GREEN}Cleanup complete!${NC}"
+
+# Remove the saved file
+if [ -f "$SELECTED_NODES_FILE" ]; then
+    rm "$SELECTED_NODES_FILE"
+    echo -e "${GREEN}Removed $SELECTED_NODES_FILE${NC}"
+fi
+
+exit 0

--- a/scripts/k8s/node-setup.sh
+++ b/scripts/k8s/node-setup.sh
@@ -349,53 +349,53 @@ generate_helm_args() {
     # Escape label key for Helm --set
     LABEL_KEY_ESCAPED=$(echo "$LABEL_KEY" | sed 's/\./\\./g')
 
-    # Node selector args
-    HELM_NODE_SELECTOR_ARGS="--set global.nodeSelector.${LABEL_KEY_ESCAPED}=${LABEL_VALUE}"
+    # Node selector args - use quotes to ensure string type (not boolean)
+    HELM_NODE_SELECTOR_ARGS="--set global.nodeSelector.${LABEL_KEY_ESCAPED}=\"${LABEL_VALUE}\""
 
     SERVICES="backend backend-python database frontend gateway runtime"
     for SERVICE in $SERVICES; do
-        HELM_NODE_SELECTOR_ARGS="$HELM_NODE_SELECTOR_ARGS --set ${SERVICE}.nodeSelector.${LABEL_KEY_ESCAPED}=${LABEL_VALUE}"
+        HELM_NODE_SELECTOR_ARGS="$HELM_NODE_SELECTOR_ARGS --set ${SERVICE}.nodeSelector.${LABEL_KEY_ESCAPED}=\"${LABEL_VALUE}\""
     done
 
-    # Tolerations args (if taint applied)
+    # Tolerations args (if taint applied) - use quotes for all string values
     if [ "$SKIP_TAINT" = false ]; then
-        HELM_TOLERATIONS_ARGS="--set global.tolerations[0].key=${LABEL_KEY}"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set global.tolerations[0].operator=Equal"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set global.tolerations[0].value=${LABEL_VALUE}"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set global.tolerations[0].effect=${TAINT_EFFECT}"
+        HELM_TOLERATIONS_ARGS="--set global.tolerations[0].key=\"${LABEL_KEY}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set global.tolerations[0].operator=\"Equal\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set global.tolerations[0].value=\"${LABEL_VALUE}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set global.tolerations[0].effect=\"${TAINT_EFFECT}\""
 
         for SERVICE in $SERVICES; do
-            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].key=${LABEL_KEY}"
-            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].operator=Equal"
-            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].value=${LABEL_VALUE}"
-            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].effect=${TAINT_EFFECT}"
+            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].key=\"${LABEL_KEY}\""
+            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].operator=\"Equal\""
+            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].value=\"${LABEL_VALUE}\""
+            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].effect=\"${TAINT_EFFECT}\""
         done
 
         # Ray cluster
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].key=${LABEL_KEY}"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].operator=Equal"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].value=${LABEL_VALUE}"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].effect=${TAINT_EFFECT}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].key=\"${LABEL_KEY}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].operator=\"Equal\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].value=\"${LABEL_VALUE}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].effect=\"${TAINT_EFFECT}\""
 
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].key=${LABEL_KEY}"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].operator=Equal"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].value=${LABEL_VALUE}"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].effect=${TAINT_EFFECT}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].key=\"${LABEL_KEY}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].operator=\"Equal\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].value=\"${LABEL_VALUE}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].effect=\"${TAINT_EFFECT}\""
 
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].key=${LABEL_KEY}"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].operator=Equal"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].value=${LABEL_VALUE}"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].effect=${TAINT_EFFECT}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].key=\"${LABEL_KEY}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].operator=\"Equal\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].value=\"${LABEL_VALUE}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].effect=\"${TAINT_EFFECT}\""
 
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].key=${LABEL_KEY}"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].operator=Equal"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].value=${LABEL_VALUE}"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].effect=${TAINT_EFFECT}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].key=\"${LABEL_KEY}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].operator=\"Equal\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].value=\"${LABEL_VALUE}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].effect=\"${TAINT_EFFECT}\""
 
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].key=${LABEL_KEY}"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].operator=Equal"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].value=${LABEL_VALUE}"
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].effect=${TAINT_EFFECT}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].key=\"${LABEL_KEY}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].operator=\"Equal\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].value=\"${LABEL_VALUE}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].effect=\"${TAINT_EFFECT}\""
     else
         HELM_TOLERATIONS_ARGS=""
     fi

--- a/scripts/k8s/node-setup.sh
+++ b/scripts/k8s/node-setup.sh
@@ -1,0 +1,500 @@
+#!/bin/bash
+#
+# DataMate Node Setup Script
+# Interactive script to select nodes with keyboard navigation (↑/↓ or j/k)
+# Automatically applies labels and taints for DataMate deployment
+#
+# Usage: ./node-setup.sh [--dry-run] [--namespace NAMESPACE] [--skip-taint]
+#
+
+set -e
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Fixed label and taint values (no prompts needed)
+NAMESPACE="datamate"
+LABEL_KEY="node-role.kubernetes.io/datamate"
+LABEL_VALUE="true"
+TAINT_EFFECT="NoSchedule"
+DRY_RUN=false
+SKIP_TAINT=false
+
+# ============================================================================
+# Argument Parsing
+# ============================================================================
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --namespace)
+                NAMESPACE="$2"
+                shift 2
+                ;;
+            --skip-taint)
+                SKIP_TAINT=true
+                shift
+                ;;
+            *)
+                echo "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+}
+
+# ============================================================================
+# Prerequisite Checks
+# ============================================================================
+
+check_prerequisites() {
+    if ! command -v kubectl &> /dev/null; then
+        echo -e "${RED}Error: kubectl is not installed${NC}"
+        exit 1
+    fi
+
+    if ! kubectl cluster-info &> /dev/null; then
+        echo -e "${RED}Error: Cannot connect to Kubernetes cluster${NC}"
+        exit 1
+    fi
+}
+
+# ============================================================================
+# Node Data Collection
+# ============================================================================
+
+fetch_nodes() {
+    echo -e "${YELLOW}Fetching available nodes...${NC}"
+
+    NODES=$(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+    NODE_COUNT=$(echo "$NODES" | wc -l | tr -d ' ')
+
+    if [ "$NODE_COUNT" -eq 0 ]; then
+        echo -e "${RED}Error: No nodes found in the cluster${NC}"
+        exit 1
+    fi
+
+    # Build node array with status info
+    NODE_ARRAY=()
+    NODE_STATUS=()
+    NODE_HAS_LABEL=()
+
+    for NODE in $NODES; do
+        NODE_ARRAY+=("$NODE")
+
+        # Get status
+        STATUS=$(kubectl get node "$NODE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+        NODE_STATUS+=("$STATUS")
+
+        # Check if already labeled
+        CURRENT_LABEL=$(kubectl get node "$NODE" -o jsonpath='{.metadata.labels.node-role\.kubernetes\.io/datamate}')
+        if [ "$CURRENT_LABEL" = "true" ]; then
+            NODE_HAS_LABEL+=("true")
+        else
+            NODE_HAS_LABEL+=("false")
+        fi
+    done
+}
+
+# ============================================================================
+# Interactive Menu Functions
+# ============================================================================
+
+# Initialize selection state array
+init_selection() {
+    SELECTED=()
+    for i in $(seq 1 $NODE_COUNT); do
+        SELECTED+=("false")
+    done
+    CURRENT_INDEX=0
+}
+
+# Print the interactive menu
+print_menu() {
+    # Clear screen and print header
+    echo -e "\033[2J\033[H"
+    echo -e "${BLUE}=====================================${NC}"
+    echo -e "${BLUE}  DataMate Node Setup${NC}"
+    echo -e "${BLUE}=====================================${NC}"
+    echo ""
+    echo -e "${CYAN}Select nodes for DataMate deployment${NC}"
+    echo ""
+
+    # Print each node with selection marker
+    for i in $(seq 0 $(($NODE_COUNT - 1))); do
+        NODE="${NODE_ARRAY[$i]}"
+        STATUS="${NODE_STATUS[$i]}"
+        HAS_LABEL="${NODE_HAS_LABEL[$i]}"
+        IS_SELECTED="${SELECTED[$i]}"
+
+        # Status display
+        if [ "$STATUS" = "True" ]; then
+            STATUS_DISPLAY="${GREEN}Ready${NC}"
+        else
+            STATUS_DISPLAY="${RED}NotReady${NC}"
+        fi
+
+        # Label marker
+        LABEL_MARKER=""
+        if [ "$HAS_LABEL" = "true" ]; then
+            LABEL_MARKER=" ${GREEN}[datamate]${NC}"
+        fi
+
+        # Selection marker
+        if [ "$IS_SELECTED" = "true" ]; then
+            MARKER="${GREEN}[x]${NC}"
+        else
+            MARKER="${NC}[ ]${NC}"
+        fi
+
+        # Highlight current row
+        if [ "$i" -eq "$CURRENT_INDEX" ]; then
+            echo -e "  ${YELLOW}→${NC} $MARKER ${CYAN}$NODE${NC} ($STATUS_DISPLAY)$LABEL_MARKER"
+        else
+            echo -e "    $MARKER $NODE ($STATUS_DISPLAY)$LABEL_MARKER"
+        fi
+    done
+
+    echo ""
+    echo -e "${YELLOW}Navigation:${NC} ↑/k: up  ↓/j: down  ${GREEN}space${NC}: toggle  ${GREEN}enter${NC}: confirm  ${RED}q${NC}: quit"
+    echo ""
+
+    # Show current selection count
+    SELECTED_COUNT=0
+    for s in "${SELECTED[@]}"; do
+        if [ "$s" = "true" ]; then
+            SELECTED_COUNT=$((SELECTED_COUNT + 1))
+        fi
+    done
+    echo -e "${BLUE}Selected: ${SELECTED_COUNT}/${NODE_COUNT} nodes${NC}"
+}
+
+# Toggle selection at current index
+toggle_selection() {
+    if [ "${SELECTED[$CURRENT_INDEX]}" = "true" ]; then
+        SELECTED[$CURRENT_INDEX]="false"
+    else
+        SELECTED[$CURRENT_INDEX]="true"
+    fi
+}
+
+# Move cursor up
+move_up() {
+    if [ "$CURRENT_INDEX" -gt 0 ]; then
+        CURRENT_INDEX=$((CURRENT_INDEX - 1))
+    fi
+}
+
+# Move cursor down
+move_down() {
+    if [ "$CURRENT_INDEX" -lt $(($NODE_COUNT - 1)) ]; then
+        CURRENT_INDEX=$((CURRENT_INDEX + 1))
+    fi
+}
+
+# Get selected nodes list
+get_selected_nodes() {
+    SELECTED_NODES=()
+    for i in $(seq 0 $(($NODE_COUNT - 1))); do
+        if [ "${SELECTED[$i]}" = "true" ]; then
+            SELECTED_NODES+=("${NODE_ARRAY[$i]}")
+        fi
+    done
+}
+
+# ============================================================================
+# Keyboard Input Handling
+# ============================================================================
+
+# Read single keypress (with fallback for non-terminal environments)
+read_key() {
+    # Check if we're in a proper terminal
+    if [ ! -t 0 ]; then
+        # Not in terminal - use simple read mode
+        read -r key
+        echo "$key"
+        return
+    fi
+
+    # Save current terminal settings
+    old_stty=$(stty -g 2>/dev/null) || return 1
+
+    # Set terminal to raw mode for single char read
+    stty raw -echo 2>/dev/null
+
+    # Read key
+    key=$(dd bs=1 count=1 2>/dev/null)
+
+    # Check for arrow keys (escape sequence)
+    if [ "$key" = $'\x1b' ]; then
+        # Read the next two chars for arrow key sequence
+        read -rs -t0.1 -n2 key2 2>/dev/null || true
+        key="${key}${key2}"
+    fi
+
+    # Restore terminal settings
+    stty "$old_stty" 2>/dev/null || true
+
+    echo "$key"
+}
+
+# Main interactive loop
+interactive_selection() {
+    init_selection
+
+    while true; do
+        print_menu
+
+        key=$(read_key)
+
+        case "$key" in
+            # Arrow up or 'k'
+            $'\x1b[A'|k)
+                move_up
+                ;;
+            # Arrow down or 'j'
+            $'\x1b[B'|j)
+                move_down
+                ;;
+            # Space - toggle selection
+            ' ')
+                toggle_selection
+                ;;
+            # Enter - confirm
+            ''|$'\x0a')
+                get_selected_nodes
+                if [ ${#SELECTED_NODES[@]} -eq 0 ]; then
+                    echo -e "${YELLOW}No nodes selected. Please select at least one node.${NC}"
+                    sleep 1
+                else
+                    return 0
+                fi
+                ;;
+            # Q - quit/skip
+            q|Q)
+                echo -e "\n${YELLOW}Skipping node setup.${NC}"
+                echo ""
+                echo "HELM_NODE_SELECTOR_ARGS="
+                echo "HELM_TOLERATIONS_ARGS="
+                exit 0
+                ;;
+        esac
+    done
+}
+
+# ============================================================================
+# Apply Configuration
+# ============================================================================
+
+apply_labels_and_taints() {
+    echo ""
+    echo -e "${GREEN}Applying configuration...${NC}"
+    echo ""
+    echo -e "${BLUE}Configuration:${NC}"
+    echo "  Label: ${LABEL_KEY}=${LABEL_VALUE}"
+    if [ "$SKIP_TAINT" = false ]; then
+        echo "  Taint: ${LABEL_KEY}=${LABEL_VALUE}:${TAINT_EFFECT}"
+    fi
+    echo ""
+
+    # Apply labels
+    for NODE in "${SELECTED_NODES[@]}"; do
+        if [ "$DRY_RUN" = true ]; then
+            echo "[DRY-RUN] kubectl label node $NODE $LABEL_KEY=$LABEL_VALUE --overwrite"
+        else
+            kubectl label node "$NODE" "$LABEL_KEY=$LABEL_VALUE" --overwrite
+            echo -e "  ${GREEN}✓${NC} Applied label to $NODE"
+        fi
+    done
+
+    # Apply taints (unless skipped)
+    if [ "$SKIP_TAINT" = false ]; then
+        for NODE in "${SELECTED_NODES[@]}"; do
+            if [ "$DRY_RUN" = true ]; then
+                echo "[DRY-RUN] kubectl taint node $NODE $LABEL_KEY=$LABEL_VALUE:$TAINT_EFFECT --overwrite"
+            else
+                kubectl taint node "$NODE" "$LABEL_KEY=$LABEL_VALUE:$TAINT_EFFECT" --overwrite
+                echo -e "  ${GREEN}✓${NC} Applied taint to $NODE"
+            fi
+        done
+    fi
+
+    echo ""
+    echo -e "${GREEN}Configuration complete!${NC}"
+}
+
+# ============================================================================
+# Generate Helm Arguments
+# ============================================================================
+
+generate_helm_args() {
+    # Escape label key for Helm --set
+    LABEL_KEY_ESCAPED=$(echo "$LABEL_KEY" | sed 's/\./\\./g')
+
+    # Node selector args
+    HELM_NODE_SELECTOR_ARGS="--set global.nodeSelector.${LABEL_KEY_ESCAPED}=${LABEL_VALUE}"
+
+    SERVICES="backend backend-python database frontend gateway runtime"
+    for SERVICE in $SERVICES; do
+        HELM_NODE_SELECTOR_ARGS="$HELM_NODE_SELECTOR_ARGS --set ${SERVICE}.nodeSelector.${LABEL_KEY_ESCAPED}=${LABEL_VALUE}"
+    done
+
+    # Tolerations args (if taint applied)
+    if [ "$SKIP_TAINT" = false ]; then
+        HELM_TOLERATIONS_ARGS="--set global.tolerations[0].key=${LABEL_KEY}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set global.tolerations[0].operator=Equal"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set global.tolerations[0].value=${LABEL_VALUE}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set global.tolerations[0].effect=${TAINT_EFFECT}"
+
+        for SERVICE in $SERVICES; do
+            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].key=${LABEL_KEY}"
+            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].operator=Equal"
+            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].value=${LABEL_VALUE}"
+            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].effect=${TAINT_EFFECT}"
+        done
+
+        # Ray cluster
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].key=${LABEL_KEY}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].operator=Equal"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].value=${LABEL_VALUE}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].effect=${TAINT_EFFECT}"
+
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].key=${LABEL_KEY}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].operator=Equal"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].value=${LABEL_VALUE}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].effect=${TAINT_EFFECT}"
+
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].key=${LABEL_KEY}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].operator=Equal"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].value=${LABEL_VALUE}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].effect=${TAINT_EFFECT}"
+
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].key=${LABEL_KEY}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].operator=Equal"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].value=${LABEL_VALUE}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].effect=${TAINT_EFFECT}"
+
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].key=${LABEL_KEY}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].operator=Equal"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].value=${LABEL_VALUE}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].effect=${TAINT_EFFECT}"
+    else
+        HELM_TOLERATIONS_ARGS=""
+    fi
+
+    echo ""
+    echo -e "${BLUE}Helm installation arguments:${NC}"
+    echo ""
+
+    # Write Helm args to temp file for Makefile to source
+    HELM_ARGS_FILE="/tmp/datamate-helm-args.sh"
+    cat > "$HELM_ARGS_FILE" <<EOF
+export HELM_NODE_SELECTOR_ARGS="$HELM_NODE_SELECTOR_ARGS"
+export HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS"
+EOF
+
+    echo -e "${GREEN}Helm arguments written to $HELM_ARGS_FILE${NC}"
+    echo ""
+    echo "To use these arguments, run:"
+    echo "  source $HELM_ARGS_FILE"
+    echo ""
+    echo "Then install with:"
+    echo "  helm upgrade datamate deployment/helm/datamate/ -n $NAMESPACE --install \\"
+    echo "    --set global.image.repository=<REGISTRY> \\"
+    echo '    $$HELM_NODE_SELECTOR_ARGS $$HELM_TOLERATIONS_ARGS'
+    echo ""
+}
+
+# ============================================================================
+# Save State for Cleanup
+# ============================================================================
+
+save_state() {
+    SELECTED_NODES_FILE="/tmp/datamate-selected-nodes.txt"
+    if [ "$DRY_RUN" = false ]; then
+        echo "${SELECTED_NODES[*]}" > "$SELECTED_NODES_FILE"
+        echo "LABEL_KEY=$LABEL_KEY" >> "$SELECTED_NODES_FILE"
+        echo "LABEL_VALUE=$LABEL_VALUE" >> "$SELECTED_NODES_FILE"
+        if [ "$SKIP_TAINT" = false ]; then
+            echo "TAINT_APPLIED=true" >> "$SELECTED_NODES_FILE"
+            echo "TAINT_EFFECT=$TAINT_EFFECT" >> "$SELECTED_NODES_FILE"
+        else
+            echo "TAINT_APPLIED=false" >> "$SELECTED_NODES_FILE"
+        fi
+        echo "NAMESPACE=$NAMESPACE" >> "$SELECTED_NODES_FILE"
+        echo -e "${GREEN}Node selection saved to $SELECTED_NODES_FILE${NC}"
+    fi
+}
+
+# ============================================================================
+# Main Entry Point
+# ============================================================================
+
+main() {
+    parse_args "$@"
+
+    echo -e "${BLUE}=====================================${NC}"
+    echo -e "${BLUE}  DataMate Node Setup${NC}"
+    echo -e "${BLUE}=====================================${NC}"
+    echo ""
+
+    # Ask if user wants to configure nodes
+    echo "Configure dedicated nodes for DataMate deployment?"
+    echo "This will apply labels and taints to selected nodes."
+    echo ""
+    echo "1. Yes - Configure nodes interactively"
+    echo "2. No - Use default scheduling (recommended for development)"
+    echo ""
+    echo -n "Enter choice [default: 2]: "
+
+    if [ ! -t 0 ]; then
+        # Not in terminal - use simple read
+        read -r choice
+    else
+        # In terminal - can use keyboard navigation
+        choice=""
+        read -r choice
+    fi
+
+    # Default to "No" if empty or not "1"
+    if [ -z "$choice" ] || [ "$choice" != "1" ]; then
+        echo ""
+        echo -e "${YELLOW}Skipping node configuration. Using default scheduling.${NC}"
+        echo ""
+        # Create empty args file
+        HELM_ARGS_FILE="/tmp/datamate-helm-args.sh"
+        cat > "$HELM_ARGS_FILE" <<EOF
+export HELM_NODE_SELECTOR_ARGS=""
+export HELM_TOLERATIONS_ARGS=""
+EOF
+        echo -e "${GREEN}Helm arguments written to $HELM_ARGS_FILE${NC}"
+        exit 0
+    fi
+
+    echo ""
+
+    check_prerequisites
+    fetch_nodes
+    interactive_selection
+    apply_labels_and_taints
+    generate_helm_args
+    save_state
+
+    exit 0
+}
+
+# Run main function
+main "$@"

--- a/scripts/k8s/node-setup.sh
+++ b/scripts/k8s/node-setup.sh
@@ -346,56 +346,58 @@ apply_labels_and_taints() {
 # ============================================================================
 
 generate_helm_args() {
-    # Escape label key for Helm --set
+    # Escape dots in label key for Helm (dots are interpreted as nested keys)
     LABEL_KEY_ESCAPED=$(echo "$LABEL_KEY" | sed 's/\./\\./g')
-
-    # Node selector args - use quotes to ensure string type (not boolean)
-    HELM_NODE_SELECTOR_ARGS="--set global.nodeSelector.${LABEL_KEY_ESCAPED}=\"${LABEL_VALUE}\""
+    
+    # Use --set-string to force string type (avoids boolean interpretation)
+    
+    # Node selector args
+    HELM_NODE_SELECTOR_ARGS="--set-string global.nodeSelector.${LABEL_KEY_ESCAPED}=${LABEL_VALUE}"
 
     SERVICES="backend backend-python database frontend gateway runtime"
     for SERVICE in $SERVICES; do
-        HELM_NODE_SELECTOR_ARGS="$HELM_NODE_SELECTOR_ARGS --set ${SERVICE}.nodeSelector.${LABEL_KEY_ESCAPED}=\"${LABEL_VALUE}\""
+        HELM_NODE_SELECTOR_ARGS="$HELM_NODE_SELECTOR_ARGS --set-string ${SERVICE}.nodeSelector.${LABEL_KEY_ESCAPED}=${LABEL_VALUE}"
     done
 
-    # Tolerations args (if taint applied) - use quotes for all string values
+    # Tolerations args (if taint applied)
     if [ "$SKIP_TAINT" = false ]; then
-        HELM_TOLERATIONS_ARGS="--set global.tolerations[0].key=\"${LABEL_KEY}\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set global.tolerations[0].operator=\"Equal\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set global.tolerations[0].value=\"${LABEL_VALUE}\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set global.tolerations[0].effect=\"${TAINT_EFFECT}\""
+        HELM_TOLERATIONS_ARGS="--set-string global.tolerations[0].key=${LABEL_KEY}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string global.tolerations[0].operator=Equal"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string global.tolerations[0].value=${LABEL_VALUE}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string global.tolerations[0].effect=${TAINT_EFFECT}"
 
         for SERVICE in $SERVICES; do
-            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].key=\"${LABEL_KEY}\""
-            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].operator=\"Equal\""
-            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].value=\"${LABEL_VALUE}\""
-            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ${SERVICE}.tolerations[0].effect=\"${TAINT_EFFECT}\""
+            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ${SERVICE}.tolerations[0].key=${LABEL_KEY}"
+            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ${SERVICE}.tolerations[0].operator=Equal"
+            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ${SERVICE}.tolerations[0].value=${LABEL_VALUE}"
+            HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ${SERVICE}.tolerations[0].effect=${TAINT_EFFECT}"
         done
 
         # Ray cluster
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].key=\"${LABEL_KEY}\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].operator=\"Equal\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].value=\"${LABEL_VALUE}\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.head.tolerations[0].effect=\"${TAINT_EFFECT}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.head.tolerations[0].key=${LABEL_KEY}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.head.tolerations[0].operator=Equal"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.head.tolerations[0].value=${LABEL_VALUE}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.head.tolerations[0].effect=${TAINT_EFFECT}"
 
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].key=\"${LABEL_KEY}\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].operator=\"Equal\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].value=\"${LABEL_VALUE}\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.worker.tolerations[0].effect=\"${TAINT_EFFECT}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.worker.tolerations[0].key=${LABEL_KEY}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.worker.tolerations[0].operator=Equal"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.worker.tolerations[0].value=${LABEL_VALUE}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.worker.tolerations[0].effect=${TAINT_EFFECT}"
 
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].key=\"${LABEL_KEY}\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].operator=\"Equal\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].value=\"${LABEL_VALUE}\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].effect=\"${TAINT_EFFECT}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].key=${LABEL_KEY}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].operator=Equal"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].value=${LABEL_VALUE}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.additionalWorkerGroups.npuGroup.tolerations[0].effect=${TAINT_EFFECT}"
 
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].key=\"${LABEL_KEY}\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].operator=\"Equal\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].value=\"${LABEL_VALUE}\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].effect=\"${TAINT_EFFECT}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].key=${LABEL_KEY}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].operator=Equal"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].value=${LABEL_VALUE}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string ray-cluster.additionalWorkerGroups.gpuGroup.tolerations[0].effect=${TAINT_EFFECT}"
 
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].key=\"${LABEL_KEY}\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].operator=\"Equal\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].value=\"${LABEL_VALUE}\""
-        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set kuberay-operator.tolerations[0].effect=\"${TAINT_EFFECT}\""
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string kuberay-operator.tolerations[0].key=${LABEL_KEY}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string kuberay-operator.tolerations[0].operator=Equal"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string kuberay-operator.tolerations[0].value=${LABEL_VALUE}"
+        HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS --set-string kuberay-operator.tolerations[0].effect=${TAINT_EFFECT}"
     else
         HELM_TOLERATIONS_ARGS=""
     fi

--- a/scripts/k8s/node-setup.sh
+++ b/scripts/k8s/node-setup.sh
@@ -247,7 +247,7 @@ read_key() {
 
     # Restore terminal settings BEFORE processing
     stty "$old_stty" 2>/dev/null || true
-    
+
     # In raw mode, Enter produces \r (carriage return), convert to \n for easier matching
     if [ "$key" = $'\x0d' ]; then
         key=$'\x0a'
@@ -348,9 +348,9 @@ apply_labels_and_taints() {
 generate_helm_args() {
     # Escape dots in label key for Helm (dots are interpreted as nested keys)
     LABEL_KEY_ESCAPED=$(echo "$LABEL_KEY" | sed 's/\./\\./g')
-    
+
     # Use --set-string to force string type (avoids boolean interpretation)
-    
+
     # Node selector args
     HELM_NODE_SELECTOR_ARGS="--set-string global.nodeSelector.${LABEL_KEY_ESCAPED}=${LABEL_VALUE}"
 
@@ -412,38 +412,6 @@ generate_helm_args() {
 export HELM_NODE_SELECTOR_ARGS="$HELM_NODE_SELECTOR_ARGS"
 export HELM_TOLERATIONS_ARGS="$HELM_TOLERATIONS_ARGS"
 EOF
-
-    echo -e "${GREEN}Helm arguments written to $HELM_ARGS_FILE${NC}"
-    echo ""
-    echo "To use these arguments, run:"
-    echo "  source $HELM_ARGS_FILE"
-    echo ""
-    echo "Then install with:"
-    echo "  helm upgrade datamate deployment/helm/datamate/ -n $NAMESPACE --install \\"
-    echo "    --set global.image.repository=<REGISTRY> \\"
-    echo '    $$HELM_NODE_SELECTOR_ARGS $$HELM_TOLERATIONS_ARGS'
-    echo ""
-}
-
-# ============================================================================
-# Save State for Cleanup
-# ============================================================================
-
-save_state() {
-    SELECTED_NODES_FILE="/tmp/datamate-selected-nodes.txt"
-    if [ "$DRY_RUN" = false ]; then
-        echo "${SELECTED_NODES[*]}" > "$SELECTED_NODES_FILE"
-        echo "LABEL_KEY=$LABEL_KEY" >> "$SELECTED_NODES_FILE"
-        echo "LABEL_VALUE=$LABEL_VALUE" >> "$SELECTED_NODES_FILE"
-        if [ "$SKIP_TAINT" = false ]; then
-            echo "TAINT_APPLIED=true" >> "$SELECTED_NODES_FILE"
-            echo "TAINT_EFFECT=$TAINT_EFFECT" >> "$SELECTED_NODES_FILE"
-        else
-            echo "TAINT_APPLIED=false" >> "$SELECTED_NODES_FILE"
-        fi
-        echo "NAMESPACE=$NAMESPACE" >> "$SELECTED_NODES_FILE"
-        echo -e "${GREEN}Node selection saved to $SELECTED_NODES_FILE${NC}"
-    fi
 }
 
 # ============================================================================
@@ -498,7 +466,6 @@ EOF
     interactive_selection
     apply_labels_and_taints
     generate_helm_args
-    save_state
 
     exit 0
 }

--- a/scripts/k8s/node-setup.sh
+++ b/scripts/k8s/node-setup.sh
@@ -245,8 +245,13 @@ read_key() {
         key="${key}${key2}"
     fi
 
-    # Restore terminal settings
+    # Restore terminal settings BEFORE processing
     stty "$old_stty" 2>/dev/null || true
+    
+    # In raw mode, Enter produces \r (carriage return), convert to \n for easier matching
+    if [ "$key" = $'\x0d' ]; then
+        key=$'\x0a'
+    fi
 
     echo "$key"
 }

--- a/scripts/k8s/node-setup.sh
+++ b/scripts/k8s/node-setup.sh
@@ -402,10 +402,6 @@ generate_helm_args() {
         HELM_TOLERATIONS_ARGS=""
     fi
 
-    echo ""
-    echo -e "${BLUE}Helm installation arguments:${NC}"
-    echo ""
-
     # Write Helm args to temp file for Makefile to source
     HELM_ARGS_FILE="/tmp/datamate-helm-args.sh"
     cat > "$HELM_ARGS_FILE" <<EOF
@@ -455,7 +451,6 @@ main() {
 export HELM_NODE_SELECTOR_ARGS=""
 export HELM_TOLERATIONS_ARGS=""
 EOF
-        echo -e "${GREEN}Helm arguments written to $HELM_ARGS_FILE${NC}"
         exit 0
     fi
 


### PR DESCRIPTION
- Add node-setup.sh script for interactive node selection with keyboard navigation
- Add node-cleanup.sh script to remove labels/taints during uninstall
- Add global.nodeSelector and global.tolerations to values.yaml
- Add nodeSelector/tolerations placeholders to all deployments:
  * Helm charts: backend, backend-python, database, frontend, gateway, runtime
  * Ray cluster: head and worker nodes
  * NPU/GPU worker groups
  * Raw K8s YAMLs: data-juicer, mineru-310, mineru-910
- Add Makefile targets: node-setup, node-cleanup
- Integrate node setup into datamate-k8s-install workflow

Features:
- Interactive keyboard navigation (↑/↓ or j/k)
- Automatic label application: node-role.kubernetes.io/datamate=true
- Optional taint application: node-role.kubernetes.io/datamate=true:NoSchedule
- Automatic Helm argument generation
- Safe defaults for development (skip option)

Fixed terminal handling issue when script runs from Makefile by:
- Detecting non-terminal environments
- Using temp file for Helm args instead of stdout capture
- Adding fallback read mode for Makefile context

## Installation

<img width="605" height="337" alt="image" src="https://github.com/user-attachments/assets/69d0d0c4-34de-46b0-a750-853df2ff70b7" />

<img width="537" height="226" alt="image" src="https://github.com/user-attachments/assets/4e9e64dd-61af-4b3c-8b05-3897f90bea6c" />

<img width="573" height="701" alt="image" src="https://github.com/user-attachments/assets/630f4c43-9733-4b2e-b416-3acc98e4b9bb" />

## Uninstallation

<img width="518" height="583" alt="image" src="https://github.com/user-attachments/assets/149a8da7-c149-4969-8902-e5eef16d2d33" />

## Label and Taint

<img width="642" height="914" alt="image" src="https://github.com/user-attachments/assets/de3a009a-4c97-4744-9ccb-2059a582e245" />

close: #499 