### PR TITLE
fix: password URL-encoding + chart-created datamate-conf Secret

### DIFF
--- a/deployment/helm/datamate/values.yaml
+++ b/deployment/helm/datamate/values.yaml
@@ -50,8 +50,9 @@ public:
       database: 1Gi
       operator: 1Gi
   secrets:
-    # Set to false when using Sealed Secrets (managed by install script)
-    create: false
+    # Set to true so the chart creates the datamate-conf Secret.
+    # The install script writes secrets into this block via sed before helm install.
+    create: true
     data:
       DB_PASSWORD: ""  # Set via install script or --set
       CERT_PASS: ""    # Set via install script for encrypted SSL keys

--- a/runtime/datamate-python/app/core/config.py
+++ b/runtime/datamate-python/app/core/config.py
@@ -1,5 +1,6 @@
 from pydantic_settings import BaseSettings
 from pydantic import model_validator
+from sqlalchemy import URL
 from typing import Optional
 
 class Settings(BaseSettings):
@@ -55,15 +56,29 @@ class Settings(BaseSettings):
 
     @model_validator(mode='after')
     def build_database_url(self):
-        """如果没有提供 database_url，则根据 MySQL 配置构建"""
+        """如果没有提供 database_url，则根据数据库配置构建。"""
         if not self.database_url:
             if self.pgsql_host:
                 if self.pgsql_password and self.pgsql_user:
-                    self.database_url = f"postgresql+asyncpg://{self.pgsql_user}:{self.pgsql_password}@{self.pgsql_host}:{self.pgsql_port}/{self.pgsql_database}"
+                    self.database_url = URL.create(
+                        "postgresql+asyncpg",
+                        username=self.pgsql_user,
+                        password=self.pgsql_password,
+                        host=self.pgsql_host,
+                        port=self.pgsql_port,
+                        database=self.pgsql_database,
+                    ).render_as_string(hide_password=False)
                 else:
                     self.database_url = f"postgresql+asyncpg://{self.pgsql_host}:{self.pgsql_port}/{self.pgsql_database}"
             elif self.mysql_password and self.mysql_user:
-                self.database_url = f"mysql+aiomysql://{self.mysql_user}:{self.mysql_password}@{self.mysql_host}:{self.mysql_port}/{self.mysql_database}"
+                self.database_url = URL.create(
+                    "mysql+aiomysql",
+                    username=self.mysql_user,
+                    password=self.mysql_password,
+                    host=self.mysql_host,
+                    port=self.mysql_port,
+                    database=self.mysql_database,
+                ).render_as_string(hide_password=False)
             else:
                 self.database_url = f"mysql+aiomysql://{self.mysql_host}:{self.mysql_port}/{self.mysql_database}"
         return self


### PR DESCRIPTION
## Summary

Fix the database password special-character bug and remove the sealed-secrets dependency, restoring the original non-sealed secret delivery path.

## Changes

### 1. Password URL-encoding (commit bc15af7a)

`runtime/datamate-python/app/core/config.py` — `build_database_url()` now uses SQLAlchemy `URL.create(...).render_as_string(hide_password=False)` instead of f-string concatenation.

- Root cause: a password like `Huawei@321` was concatenated directly into the URL, so the first `@` was parsed as the userinfo/host separator, yielding a wrong host (`321@datamate-database`) and a `Name or service not known` DNS error.
- `URL.create()` percent-encodes reserved characters in the password automatically (`@` → `%40`), and handles all reserved chars (`:`, `/`, `#`, `?`, `&`, `=`, `+`, etc.), not just `@`.

### 2. Chart-created datamate-conf Secret (commit b056f3c3)

`deployment/helm/datamate/values.yaml` — `public.secrets.create: false → true` so the chart's `secret.yaml` template generates the `datamate-conf` Secret from `secrets.data`. The install script writes secrets into this block via sed before `helm install`.

## Verification

- `URL.create()` tested with `Huawei@321` and other reserved chars.
- Confirmed `datamate-conf` Secret consumers (DB_PASSWORD, HOME_PAGE_URL, JWT_SECRET, LABEL_STUDIO_PASSWORD/TOKEN, CERT_PASS, DOMAIN) all resolve via `secretKeyRef`.

## Note

The matching install-script changes live in `ModelEngine-Group/DataMate-Deploy`.
